### PR TITLE
0.10.0 me: profile, inbox, preferences, phone, pushover

### DIFF
--- a/app/controllers/command_tower/me/inbox_controller.rb
+++ b/app/controllers/command_tower/me/inbox_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class InboxController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def index
+        deserialized = CommandTower::Deserializers::Messaging::Inbox::ListDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        render_application_result(CommandTower::Workflows::Messaging::Inbox::ListWorkflow.call(
+          user: current_user, limit: deserialized.input.limit, offset: deserialized.input.offset, scope: deserialized.input.scope
+        ))
+      end
+
+      def show
+        run_item_workflow(CommandTower::Workflows::Messaging::Inbox::ShowWorkflow)
+      end
+
+      def open
+        run_item_workflow(CommandTower::Workflows::Messaging::Inbox::OpenWorkflow)
+      end
+
+      def archive
+        run_item_workflow(CommandTower::Workflows::Messaging::Inbox::ArchiveWorkflow)
+      end
+
+      def destroy
+        run_item_workflow(CommandTower::Workflows::Messaging::Inbox::DeleteWorkflow)
+      end
+
+      def unread_count
+        render_application_result(CommandTower::Workflows::Messaging::Inbox::UnreadCountWorkflow.call(user: current_user))
+      end
+
+      def bulk_read
+        run_bulk_workflow(CommandTower::Workflows::Messaging::Inbox::BulkReadWorkflow)
+      end
+
+      def bulk_unread
+        run_bulk_workflow(CommandTower::Workflows::Messaging::Inbox::BulkUnreadWorkflow)
+      end
+
+      def bulk_archive
+        run_bulk_workflow(CommandTower::Workflows::Messaging::Inbox::BulkArchiveWorkflow)
+      end
+
+      def bulk_restore
+        run_bulk_workflow(CommandTower::Workflows::Messaging::Inbox::BulkRestoreWorkflow)
+      end
+
+      def bulk_delete
+        run_bulk_workflow(CommandTower::Workflows::Messaging::Inbox::BulkDeleteWorkflow)
+      end
+
+      private
+
+      def run_item_workflow(workflow)
+        deserialized = CommandTower::Deserializers::Messaging::Inbox::ShowDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        render_application_result(workflow.call(user: current_user, inbox_item_id: deserialized.input.inbox_item_id))
+      end
+
+      def run_bulk_workflow(workflow)
+        deserialized = CommandTower::Deserializers::Messaging::Inbox::BulkIdsDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        render_application_result(workflow.call(user: current_user, inbox_item_ids: deserialized.input.inbox_item_ids))
+      end
+
+      def render_deserializer_errors
+        render_application_result(CommandTower::Workflows::WorkflowResult.failure(
+          errors: [CommandTower::Errors::ValidationError.new(details: { base: "Invalid request parameters" })],
+          http_status: :unprocessable_entity
+        ))
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/name_controller.rb
+++ b/app/controllers/command_tower/me/name_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class NameController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def update
+        deserialized = CommandTower::Deserializers::Me::UpdateNameDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        result = CommandTower::Workflows::Me::UpdateNameWorkflow.call(
+          current_user: current_user,
+          first_name: deserialized.input.first_name,
+          last_name: deserialized.input.last_name,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      private
+
+      def render_deserializer_errors
+        render_application_result(
+          CommandTower::Workflows::WorkflowResult.failure(
+            errors: [CommandTower::Errors::ValidationError.new(details: { base: "Missing required fields" })],
+            http_status: :unprocessable_entity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/password_controller.rb
+++ b/app/controllers/command_tower/me/password_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class PasswordController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def update
+        deserialized = CommandTower::Deserializers::Me::ChangePasswordDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        result = CommandTower::Workflows::Me::ChangePasswordWorkflow.call(
+          current_user: current_user,
+          current_password: deserialized.input.current_password,
+          password: deserialized.input.password,
+          password_confirmation: deserialized.input.password_confirmation
+        )
+        render_application_result(result)
+      end
+
+      private
+
+      def render_deserializer_errors
+        render_application_result(
+          CommandTower::Workflows::WorkflowResult.failure(
+            errors: [CommandTower::Errors::ValidationError.new(details: { base: "Missing required fields" })],
+            http_status: :unprocessable_entity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/phone_controller.rb
+++ b/app/controllers/command_tower/me/phone_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class PhoneController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def update
+        deserialized = CommandTower::Deserializers::Me::UpdatePhoneDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        result = CommandTower::Workflows::Me::UpdatePhoneWorkflow.call(
+          current_user: current_user,
+          phone_number: deserialized.input.phone_number,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      def destroy
+        result = CommandTower::Workflows::Me::ClearPhoneWorkflow.call(
+          current_user: current_user,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      private
+
+      def render_deserializer_errors
+        render_application_result(
+          CommandTower::Workflows::WorkflowResult.failure(
+            errors: [CommandTower::Errors::ValidationError.new(details: { base: "Missing required fields" })],
+            http_status: :unprocessable_entity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/phone_verification/verifications_controller.rb
+++ b/app/controllers/command_tower/me/phone_verification/verifications_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    module PhoneVerification
+      class VerificationsController < CommandTower::ApplicationController
+        include CommandTower::Auth::AuthenticationBoundary
+        include CommandTower::Auth::AuthorizationBoundary
+
+        before_action :authenticate_request!
+        before_action :authorize_request!
+
+        def create
+          result = CommandTower::Workflows::Me::PhoneVerification::SendWorkflow.call(
+            current_user: current_user,
+            auth_context: current_auth_context
+          )
+          render_application_result(result)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/phone_verification/verify_controller.rb
+++ b/app/controllers/command_tower/me/phone_verification/verify_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    module PhoneVerification
+      class VerifyController < CommandTower::ApplicationController
+        include CommandTower::Auth::AuthenticationBoundary
+        include CommandTower::Auth::AuthorizationBoundary
+
+        before_action :authenticate_request!
+        before_action :authorize_request!
+
+        def create
+          deserialized = CommandTower::Deserializers::Me::PhoneVerification::VerifyDeserializer.call(params)
+          unless deserialized.success?
+            return render_application_result(
+              CommandTower::Workflows::WorkflowResult.failure(
+                errors: [CommandTower::Errors::Account::PhoneVerificationCodeInvalidError.new],
+                http_status: :unprocessable_entity
+              )
+            )
+          end
+
+          result = CommandTower::Workflows::Me::PhoneVerification::VerifyWorkflow.call(
+            current_user: current_user,
+            code: deserialized.input.code,
+            auth_context: current_auth_context
+          )
+          render_application_result(result)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/preferences_controller.rb
+++ b/app/controllers/command_tower/me/preferences_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class PreferencesController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def show
+        deserialized = CommandTower::Deserializers::Messaging::Preferences::ShowDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        render_application_result(
+          CommandTower::Workflows::Messaging::Preferences::ShowWorkflow.call(user: current_user)
+        )
+      end
+
+      def update
+        deserialized = CommandTower::Deserializers::Messaging::Preferences::UpdateDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        render_application_result(
+          CommandTower::Workflows::Messaging::Preferences::UpdateWorkflow.call(
+            user: current_user,
+            notification_type_key: deserialized.input.notification_type_key,
+            preference_state: deserialized.input.preference_state,
+          )
+        )
+      end
+
+      private
+
+      def render_deserializer_errors
+        render_application_result(
+          CommandTower::Workflows::WorkflowResult.failure(
+            errors: [CommandTower::Errors::ValidationError.new(details: { base: "Invalid request parameters" })],
+            http_status: :unprocessable_entity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/pushover/verifications_controller.rb
+++ b/app/controllers/command_tower/me/pushover/verifications_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    module Pushover
+      class VerificationsController < CommandTower::ApplicationController
+        include CommandTower::Auth::AuthenticationBoundary
+        include CommandTower::Auth::AuthorizationBoundary
+
+        before_action :authenticate_request!
+        before_action :authorize_request!
+
+        def create
+          result = CommandTower::Workflows::Me::Pushover::VerifyWorkflow.call(
+            current_user: current_user,
+            auth_context: current_auth_context
+          )
+          render_application_result(result)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me/pushover_controller.rb
+++ b/app/controllers/command_tower/me/pushover_controller.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Me
+    class PushoverController < CommandTower::ApplicationController
+      include CommandTower::Auth::AuthenticationBoundary
+      include CommandTower::Auth::AuthorizationBoundary
+
+      before_action :authenticate_request!
+      before_action :authorize_request!
+
+      def show
+        result = CommandTower::Workflows::Me::Pushover::ShowWorkflow.call(
+          current_user: current_user,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      def create
+        deserialized = CommandTower::Deserializers::Me::Pushover::CredentialsDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        result = CommandTower::Workflows::Me::Pushover::CreateWorkflow.call(
+          current_user: current_user,
+          user_key: deserialized.input.user_key,
+          application_token: deserialized.input.application_token,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      def update
+        deserialized = CommandTower::Deserializers::Me::Pushover::CredentialsDeserializer.call(params)
+        return render_deserializer_errors unless deserialized.success?
+
+        result = CommandTower::Workflows::Me::Pushover::ReplaceWorkflow.call(
+          current_user: current_user,
+          user_key: deserialized.input.user_key,
+          application_token: deserialized.input.application_token,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      def destroy
+        result = CommandTower::Workflows::Me::Pushover::DestroyWorkflow.call(
+          current_user: current_user,
+          auth_context: current_auth_context
+        )
+        render_application_result(result)
+      end
+
+      private
+
+      def render_deserializer_errors
+        render_application_result(
+          CommandTower::Workflows::WorkflowResult.failure(
+            errors: [CommandTower::Errors::ValidationError.new(details: { base: "Missing required fields" })],
+            http_status: :unprocessable_entity
+          )
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/command_tower/me_controller.rb
+++ b/app/controllers/command_tower/me_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CommandTower
+  class MeController < CommandTower::ApplicationController
+    include CommandTower::Auth::AuthenticationBoundary
+    include CommandTower::Auth::AuthorizationBoundary
+
+    before_action :authenticate_request!
+    before_action :authorize_request!
+
+    def show
+      result = CommandTower::Workflows::Me::ShowWorkflow.call(
+        current_user: current_user,
+        auth_context: current_auth_context
+      )
+      render_application_result(result)
+    end
+  end
+end

--- a/app/controllers/command_tower/profile_controller.rb
+++ b/app/controllers/command_tower/profile_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CommandTower
+  class ProfileController < CommandTower::ApplicationController
+    include CommandTower::Auth::AuthenticationBoundary
+    include CommandTower::Auth::AuthorizationBoundary
+
+    before_action :authenticate_request!
+    before_action :authorize_request!
+
+    def show
+      result = CommandTower::Workflows::Profile::ShowWorkflow.call(
+        current_user: current_user,
+        auth_context: current_auth_context
+      )
+      render_application_result(result)
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/me/change_password_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/me/change_password_deserializer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Me
+      # Transport-only: required fields, camelCase/snake_case, blank detection.
+      # LoginStrategy owns password policy, confirmation match, and current-password check.
+      class ChangePasswordDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+        Input = Data.define(:current_password, :password, :password_confirmation)
+
+        def call(params)
+          current_password = params[:current_password] || params[:currentPassword]
+          password = params[:password]
+          password_confirmation = params[:password_confirmation] || params[:passwordConfirmation]
+
+          if blank?(current_password) || blank?(password) || blank?(password_confirmation)
+            return failure(errors: { message: "missing_required_fields" })
+          end
+
+          unless current_password.is_a?(String) && password.is_a?(String) && password_confirmation.is_a?(String)
+            return failure(errors: { message: "invalid_field_types" })
+          end
+
+          success(
+            Input.new(
+              current_password: current_password,
+              password: password,
+              password_confirmation: password_confirmation
+            )
+          )
+        end
+
+        private
+
+        def blank?(value)
+          value.nil? || (value.is_a?(String) && value.strip.empty?)
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/me/phone_verification/verify_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/me/phone_verification/verify_deserializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Me
+      module PhoneVerification
+        class VerifyDeserializer
+          Result = Struct.new(:success?, :input, :errors, keyword_init: true)
+          Input = Struct.new(:code, keyword_init: true)
+
+          def self.call(params)
+            raw = params[:code].presence || params.dig(:phone_verification, :code).presence
+            code = raw.to_s.strip
+
+            if code.blank?
+              return Result.new(
+                success?: false,
+                input: nil,
+                errors: { code: "is required" }
+              )
+            end
+
+            Result.new(success?: true, input: Input.new(code:), errors: {})
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/me/pushover/credentials_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/me/pushover/credentials_deserializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Me
+      module Pushover
+        class CredentialsDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+          Input = Data.define(:user_key, :application_token)
+
+          def call(params)
+            user_key = extract(params, :user_key, :userKey)
+            application_token = extract(params, :application_token, :applicationToken)
+
+            if user_key.blank? || application_token.blank?
+              return failure(errors: { message: "missing_required_fields" })
+            end
+
+            success(Input.new(user_key:, application_token:))
+          end
+
+          private
+
+          def extract(params, snake, camel)
+            raw = params[snake] || params[camel]
+            raw.nil? ? "" : raw.to_s.strip
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/me/update_name_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/me/update_name_deserializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Me
+      class UpdateNameDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+        Input = Data.define(:first_name, :last_name)
+
+        def call(params)
+          first_name = (params[:first_name] || params[:firstName]).to_s.strip
+          last_name = (params[:last_name] || params[:lastName]).to_s.strip
+
+          if first_name.blank? || last_name.blank?
+            return failure(errors: { message: "missing_required_fields" })
+          end
+
+          success(Input.new(first_name:, last_name:))
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/me/update_phone_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/me/update_phone_deserializer.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Me
+      class UpdatePhoneDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+        Input = Data.define(:phone_number)
+
+        def call(params)
+          raw = params[:phone_number] || params[:phoneNumber]
+          phone_number = raw.nil? ? "" : raw.to_s
+
+          if phone_number.strip.blank?
+            return failure(errors: { message: "missing_required_fields" })
+          end
+
+          success(Input.new(phone_number:))
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/messaging/inbox.rb
+++ b/app/deserializers/command_tower/deserializers/messaging/inbox.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Messaging
+      module Inbox
+        class ListDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+          Input = Data.define(:limit, :offset, :scope)
+          DEFAULT_LIMIT = 50
+          MAX_LIMIT = 100
+          ALLOWED_SCOPES = %w[inbox archived].freeze
+
+          def call(params)
+            limit = integer(params[:limit], default: DEFAULT_LIMIT, minimum: 1, maximum: MAX_LIMIT)
+            return failure(errors: { message: "invalid_limit" }) if limit.nil?
+
+            offset = integer(params[:offset], default: 0, minimum: 0)
+            return failure(errors: { message: "invalid_offset" }) if offset.nil?
+
+            scope = params[:scope].presence || "inbox"
+            return failure(errors: { message: "invalid_scope" }) unless scope.is_a?(String) && ALLOWED_SCOPES.include?(scope.strip)
+
+            success(Input.new(limit:, offset:, scope: scope.strip))
+          end
+
+          private
+
+          def integer(raw, default:, minimum:, maximum: nil)
+            return default if raw.nil? || raw.is_a?(String) && raw.strip.empty?
+
+            value = raw.is_a?(Integer) ? raw : (Integer(raw, 10) if raw.is_a?(String) && /\A-?\d+\z/.match?(raw.strip))
+            return if value.nil? || value < minimum || maximum && value > maximum
+
+            value
+          rescue ArgumentError
+            nil
+          end
+        end
+
+        class ShowDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+          Input = Data.define(:inbox_item_id)
+
+          def call(params)
+            value = positive_integer(params[:id])
+            return failure(errors: { message: "invalid_inbox_item_id" }) unless value
+
+            success(Input.new(inbox_item_id: value))
+          end
+
+          private
+
+          def positive_integer(raw)
+            value = raw.is_a?(Integer) ? raw : (Integer(raw, 10) if raw.is_a?(String) && /\A\d+\z/.match?(raw.strip))
+            value if value&.positive?
+          rescue ArgumentError
+            nil
+          end
+        end
+
+        class BulkIdsDeserializer < ShowDeserializer
+          Input = Data.define(:inbox_item_ids)
+          MAX_IDS = 100
+
+          def call(params)
+            raw = params[:ids]
+            return failure(errors: { message: "invalid_ids" }) unless raw.is_a?(Array) && raw.any? && raw.size <= MAX_IDS
+
+            values = raw.map { |entry| positive_integer(entry) }
+            return failure(errors: { message: "invalid_ids" }) if values.any?(&:nil?)
+
+            success(Input.new(inbox_item_ids: values.uniq))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/messaging/preferences/show_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/messaging/preferences/show_deserializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Messaging
+      module Preferences
+        class ShowDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+          Input = Data.define
+
+          def call(_params)
+            success(Input.new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/deserializers/command_tower/deserializers/messaging/preferences/update_deserializer.rb
+++ b/app/deserializers/command_tower/deserializers/messaging/preferences/update_deserializer.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Deserializers
+    module Messaging
+      module Preferences
+        class UpdateDeserializer < CommandTower::Deserializers::ApplicationDeserializer
+          Input = Data.define(:notification_type_key, :preference_state)
+
+          ROUTING_KEYS = %w[controller action format notification_type_key preference].freeze
+          ALLOWED_PREFERENCE_KEYS = %w[inboxEnabled channels].freeze
+
+          def call(params)
+            raw = normalize_hash(params)
+            return failure(errors: { message: "invalid_notification_type_key" }) if raw.nil?
+
+            notification_type_key = raw["notification_type_key"]
+            if notification_type_key.nil? || !notification_type_key.is_a?(String) || notification_type_key.strip.empty?
+              return failure(errors: { message: "invalid_notification_type_key" })
+            end
+
+            extras = raw.keys - ROUTING_KEYS - ["preferences"]
+            return failure(errors: { message: "unexpected_fields" }) if extras.any?
+            return failure(errors: { message: "missing_preferences" }) unless raw.key?("preferences")
+
+            preferences = raw["preferences"]
+            return failure(errors: { message: "invalid_preferences" }) unless preferences.is_a?(Hash)
+
+            preference_state = parse_preferences(preferences)
+            return preference_state if preference_state.is_a?(DeserializerResult)
+
+            success(
+              Input.new(
+                notification_type_key: notification_type_key.strip,
+                preference_state:,
+              ),
+            )
+          end
+
+          private
+
+          def normalize_hash(params)
+            hash =
+              if params.respond_to?(:to_unsafe_h)
+                params.to_unsafe_h
+              elsif params.respond_to?(:to_h)
+                params.to_h
+              else
+                return nil
+              end
+
+            hash.each_with_object({}) do |(key, value), result|
+              result[key.to_s] =
+                if value.respond_to?(:to_unsafe_h)
+                  value.to_unsafe_h.transform_keys(&:to_s)
+                elsif value.is_a?(Hash)
+                  value.transform_keys(&:to_s)
+                else
+                  value
+                end
+            end
+          end
+
+          def parse_preferences(preferences)
+            unknown = preferences.keys - ALLOWED_PREFERENCE_KEYS
+            return failure(errors: { message: "unexpected_preference_fields" }) if unknown.any?
+
+            state = {}
+
+            if preferences.key?("channels")
+              channels = preferences["channels"]
+              return failure(errors: { message: "invalid_channels" }) unless channels.is_a?(Hash)
+
+              parsed_channels = {}
+              channels.each do |channel_key, channel_value|
+                return failure(errors: { message: "invalid_channel_key" }) unless channel_key.is_a?(String) || channel_key.is_a?(Symbol)
+                return failure(errors: { message: "invalid_channel_value" }) unless [true, false].include?(channel_value)
+
+                parsed_channels[channel_key.to_s] = channel_value
+              end
+              state["channels"] = parsed_channels
+            end
+
+            if preferences.key?("inboxEnabled")
+              inbox = preferences["inboxEnabled"]
+              return failure(errors: { message: "invalid_inbox_enabled" }) unless [true, false].include?(inbox)
+
+              state["inbox"] = inbox
+            end
+
+            state
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_already_verified_error.rb
+++ b/app/errors/command_tower/errors/account/phone_already_verified_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneAlreadyVerifiedError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_already_verified"
+        end
+
+        def message
+          "Phone number is already verified"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_missing_error.rb
+++ b/app/errors/command_tower/errors/account/phone_missing_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneMissingError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_missing"
+        end
+
+        def message
+          "Phone number is required"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_verification_code_invalid_error.rb
+++ b/app/errors/command_tower/errors/account/phone_verification_code_invalid_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneVerificationCodeInvalidError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_verification_code_invalid"
+        end
+
+        def message
+          "Incorrect verification code"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_verification_expired_error.rb
+++ b/app/errors/command_tower/errors/account/phone_verification_expired_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneVerificationExpiredError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_verification_code_expired"
+        end
+
+        def message
+          "Verification code has expired"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_verification_send_failed_error.rb
+++ b/app/errors/command_tower/errors/account/phone_verification_send_failed_error.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneVerificationSendFailedError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_verification_send_failed"
+        end
+
+        def message
+          "Unable to send verification code"
+        end
+
+        def retryable?
+          true
+        end
+
+        def log_level
+          :error
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_verification_stale_error.rb
+++ b/app/errors/command_tower/errors/account/phone_verification_stale_error.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneVerificationStaleError < CommandTower::Errors::ApplicationError
+        def code
+          "phone_verification_stale"
+        end
+
+        def message
+          "Verification code is no longer valid for this phone"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/phone_verification_throttled_error.rb
+++ b/app/errors/command_tower/errors/account/phone_verification_throttled_error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PhoneVerificationThrottledError < CommandTower::Errors::ApplicationError
+        attr_reader :resend_available_at
+
+        def initialize(resend_available_at: nil)
+          @resend_available_at = resend_available_at
+          super()
+        end
+
+        def code
+          "phone_verification_throttled"
+        end
+
+        def message
+          "Please wait before requesting another code"
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/pushover_already_configured_error.rb
+++ b/app/errors/command_tower/errors/account/pushover_already_configured_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PushoverAlreadyConfiguredError < CommandTower::Errors::ApplicationError
+        def code
+          "pushover_already_configured"
+        end
+
+        def message
+          "Pushover is already configured"
+        end
+
+        def log_level
+          :info
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/pushover_capability_unavailable_error.rb
+++ b/app/errors/command_tower/errors/account/pushover_capability_unavailable_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PushoverCapabilityUnavailableError < CommandTower::Errors::ApplicationError
+        def code
+          "pushover_capability_unavailable"
+        end
+
+        def message
+          "Pushover is currently unavailable"
+        end
+
+        def log_level
+          :warn
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/pushover_not_configured_error.rb
+++ b/app/errors/command_tower/errors/account/pushover_not_configured_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PushoverNotConfiguredError < CommandTower::Errors::ApplicationError
+        def code
+          "pushover_not_configured"
+        end
+
+        def message
+          "Pushover is not configured"
+        end
+
+        def log_level
+          :info
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/pushover_provider_unavailable_error.rb
+++ b/app/errors/command_tower/errors/account/pushover_provider_unavailable_error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PushoverProviderUnavailableError < CommandTower::Errors::ApplicationError
+        def code
+          "pushover_provider_unavailable"
+        end
+
+        def message
+          "Pushover provider is temporarily unavailable"
+        end
+
+        def log_level
+          :warn
+        end
+      end
+    end
+  end
+end

--- a/app/errors/command_tower/errors/account/pushover_verification_failed_error.rb
+++ b/app/errors/command_tower/errors/account/pushover_verification_failed_error.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Errors
+    module Account
+      class PushoverVerificationFailedError < CommandTower::Errors::ApplicationError
+        def initialize(code: "pushover_verification_failed", message: "Pushover verification failed", details: nil, cause: nil)
+          @code = code
+          @message = message
+          super(details:, cause:)
+        end
+
+        def code
+          @code
+        end
+
+        def message
+          @message
+        end
+
+        def log_level
+          :info
+        end
+      end
+    end
+  end
+end

--- a/app/models/command_tower/messaging/endpoint_pushover_credential.rb
+++ b/app/models/command_tower/messaging/endpoint_pushover_credential.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    class EndpointPushoverCredential < CommandTower::ApplicationRecord
+      self.table_name = "messaging_endpoint_pushover_credentials"
+
+      belongs_to :endpoint,
+                 class_name: "CommandTower::Messaging::Endpoint",
+                 foreign_key: :messaging_endpoint_id,
+                 inverse_of: :pushover_credential
+
+      validates :user_key_ciphertext, presence: true
+      validates :application_token_ciphertext, presence: true
+      validates :encryption_key_version, presence: true
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/me/account_serializer.rb
+++ b/app/serializers/command_tower/serializers/me/account_serializer.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Me
+      class AccountSerializer
+        def self.serialize(user, capabilities:)
+          first_name = user.first_name.to_s
+          last_name = user.last_name.to_s
+          full_name = [first_name, last_name].map(&:strip).reject(&:empty?).join(" ")
+          full_name = user.full_name.strip if full_name.empty? && user.respond_to?(:full_name)
+
+          {
+            id: user.id,
+            firstName: first_name,
+            lastName: last_name,
+            fullName: full_name,
+            username: user.username,
+            email: user.email,
+            emailValidated: user.email_validated,
+            phoneNumber: phone_number_for(user),
+            phoneNumberValidated: phone_number_validated_for(user),
+            roles: user.roles,
+            createdAt: user.created_at&.iso8601,
+            capabilities: capabilities
+          }
+        end
+
+        def self.phone_number_for(user)
+          return nil unless user.respond_to?(:phone_number)
+
+          user.phone_number.presence
+        end
+        private_class_method :phone_number_for
+
+        def self.phone_number_validated_for(user)
+          return false unless user.respond_to?(:phone_number_validated)
+
+          !!user.phone_number_validated
+        end
+        private_class_method :phone_number_validated_for
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/me/change_password_response_serializer.rb
+++ b/app/serializers/command_tower/serializers/me/change_password_response_serializer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Me
+      class ChangePasswordResponseSerializer
+        def self.serialize(message: "Password updated successfully.")
+          { message: message }
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/me/pushover_serializer.rb
+++ b/app/serializers/command_tower/serializers/me/pushover_serializer.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Me
+      class PushoverSerializer
+        def self.serialize(safe_view)
+          new(safe_view).serialize
+        end
+
+        def self.unconfigured
+          {
+            configured: false,
+            actions: {
+              canCreate: true,
+              canVerify: false,
+              canReplace: false,
+              canRemove: false
+            }
+          }
+        end
+
+        def initialize(safe_view)
+          @safe_view = safe_view
+        end
+
+        def serialize
+          return self.class.unconfigured if @safe_view.nil?
+
+          {
+            configured: true,
+            id: @safe_view.id,
+            channelKey: @safe_view.channel_key,
+            lifecycleState: @safe_view.lifecycle_state,
+            verificationState: @safe_view.verification_state,
+            maskedDisplayValue: @safe_view.masked_display_value,
+            credentialsConfigured: !!@safe_view.credentials_configured,
+            verifiedAt: @safe_view.verified_at&.iso8601,
+            createdAt: @safe_view.created_at&.iso8601,
+            updatedAt: @safe_view.updated_at&.iso8601,
+            actions: actions_for(@safe_view)
+          }
+        end
+
+        private
+
+        def actions_for(view)
+          active = view.lifecycle_state.to_s == "active"
+          {
+            canCreate: false,
+            canVerify: active,
+            canReplace: active,
+            canRemove: active
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/messaging/inbox.rb
+++ b/app/serializers/command_tower/serializers/messaging/inbox.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Messaging
+      module Inbox
+        class ItemSerializer
+          def self.serialize(item)
+            { id: item.fetch(:id), title: item.fetch(:title), status: item.fetch(:status),
+              read: item[:viewed_at].present?, viewedAt: item[:viewed_at]&.iso8601,
+              createdAt: item[:created_at]&.iso8601, updatedAt: item[:updated_at]&.iso8601 }
+          end
+        end
+
+        class DetailSerializer
+          def self.serialize(item)
+            ItemSerializer.serialize(item).merge(
+              body: item.fetch(:body), metadata: item[:metadata],
+              notificationTypeKey: item.fetch(:notification_type_key)
+            )
+          end
+        end
+
+        class BulkResultSerializer
+          def self.serialize(result)
+            { ids: result.fetch(:ids), count: result.fetch(:count), changedCount: result.fetch(:changed_count) }
+          end
+        end
+
+        class UnreadCountSerializer
+          def self.serialize(payload)
+            { count: payload.fetch(:count) }
+          end
+        end
+
+        class PaginationMetaSerializer
+          def self.serialize(pagination)
+            { limit: pagination.fetch(:limit), offset: pagination.fetch(:offset),
+              totalCount: pagination.fetch(:total_count) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/messaging/preferences/catalog_serializer.rb
+++ b/app/serializers/command_tower/serializers/messaging/preferences/catalog_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Messaging
+      module Preferences
+        class CatalogSerializer
+          def self.serialize(catalog)
+            {
+              categories: catalog.categories.map { |category| CategorySerializer.serialize(category) },
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/messaging/preferences/category_serializer.rb
+++ b/app/serializers/command_tower/serializers/messaging/preferences/category_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Messaging
+      module Preferences
+        class CategorySerializer
+          def self.serialize(category)
+            {
+              key: category.key,
+              label: category.label,
+              description: category.description,
+              order: category.order,
+              notifications: category.notifications.map { |notification|
+                NotificationSerializer.serialize(notification)
+              },
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/command_tower/serializers/messaging/preferences/notification_serializer.rb
+++ b/app/serializers/command_tower/serializers/messaging/preferences/notification_serializer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Serializers
+    module Messaging
+      module Preferences
+        class NotificationSerializer
+          def self.serialize(notification)
+            {
+              key: notification.key,
+              label: notification.label,
+              description: notification.description,
+              order: notification.order,
+              configurable: notification.configurable,
+              mandatory: notification.mandatory,
+              inboxAvailable: notification.inbox_available,
+              allowedChannels: notification.allowed_channels,
+              availableChannels: notification.available_channels,
+              preferences: {
+                inboxEnabled: notification.inbox_enabled,
+                channels: notification.channels,
+                storedOverridePresent: notification.stored_override_present,
+              },
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone/normalizer.rb
+++ b/app/services/command_tower/identity/phone/normalizer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "phonelib"
+
+module CommandTower
+  module Identity
+    module Phone
+      # Canonical E.164 normalize/reject entry point for Identity phone numbers.
+      class Normalizer
+        DEFAULT_COUNTRY = "US"
+
+        BLANK_MESSAGE = "is required"
+        INVALID_MESSAGE = "is invalid"
+
+        Normalized = Data.define(:normalized, :message) do
+          def success? = message.nil?
+
+          def failure? = !success?
+        end
+
+        def self.call(phone_number:)
+          raw = phone_number.to_s.strip
+          return failure(BLANK_MESSAGE) if raw.blank?
+
+          parsed = Phonelib.parse(raw, DEFAULT_COUNTRY)
+          return failure(INVALID_MESSAGE) unless parsed.valid?
+
+          e164 = parsed.e164.to_s
+          return failure(INVALID_MESSAGE) if e164.blank?
+
+          Normalized.new(normalized: e164, message: nil)
+        end
+
+        def self.failure(message)
+          Normalized.new(normalized: nil, message:)
+        end
+        private_class_method :failure
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone_verification/sms_configuration.rb
+++ b/app/services/command_tower/identity/phone_verification/sms_configuration.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Identity
+    module PhoneVerification
+      # Readiness detector for Identity phone-verification OTP SMS delivery.
+      # Distinct from Messaging notification SMS Configuration — same Twilio ENV
+      # names may be shared, but adapters and sender resolution differ.
+      class SmsConfiguration
+        def self.sms_ready?
+          new.sms_ready?
+        end
+
+        def sms_ready?
+          return false unless phone_verification.enable
+
+          case adapter_name
+          when "twilio"
+            twilio_credentials_present?
+          when "fake", "log"
+            # Intentional non-provider transports for test/development only.
+            !Rails.env.production?
+          else
+            false
+          end
+        end
+
+        def adapter_name
+          phone_verification.sms_adapter.to_s
+        end
+
+        private
+
+        def phone_verification
+          CommandTower.config.identity.phone_verification
+        end
+
+        def twilio_credentials_present?
+          account_sid.present? && auth_token.present? && from_number.present?
+        end
+
+        def account_sid
+          CredentialResolution.resolve(:twilio).account_sid
+        end
+
+        def auth_token
+          CredentialResolution.resolve(:twilio).auth_token
+        end
+
+        def from_number
+          phone_verification.sms_from.to_s.strip.presence ||
+            ENV["TWILIO_FROM"].to_s.strip.presence ||
+            ENV["TWILIO_FROM_NUMBER"].to_s.strip.presence
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone_verification/sms_transport.rb
+++ b/app/services/command_tower/identity/phone_verification/sms_transport.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Identity
+    module PhoneVerification
+      # Vendor-agnostic SMS delivery for phone OTP. Identity depends on this interface only.
+      module SmsTransport
+        Result = Struct.new(:success?, :error_code, :error_message, keyword_init: true)
+
+        class << self
+          attr_writer :adapter
+
+          def adapter
+            @adapter ||= build_adapter
+          end
+
+          def reset_adapter!
+            @adapter = nil
+          end
+
+          def deliver(to:, body:)
+            adapter.deliver(to: to, body: body)
+          end
+
+          private
+
+          def build_adapter
+            name = CommandTower.config.identity.phone_verification.sms_adapter.to_s
+            case name
+            when "twilio"
+              Adapters::TwilioAdapter.new
+            when "log"
+              Adapters::LogAdapter.new
+            else
+              Adapters::FakeAdapter.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone_verification/sms_transport/adapters/fake_adapter.rb
+++ b/app/services/command_tower/identity/phone_verification/sms_transport/adapters/fake_adapter.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Identity
+    module PhoneVerification
+      module SmsTransport
+        module Adapters
+          # In-memory / no-network adapter for tests and local default.
+          class FakeAdapter
+            class << self
+              attr_accessor :deliveries, :fail_with
+
+              def reset!
+                self.deliveries = []
+                self.fail_with = nil
+              end
+            end
+
+            self.reset!
+
+            def deliver(to:, body:)
+              if self.class.fail_with
+                code, message = self.class.fail_with
+                return SmsTransport::Result.new(success?: false, error_code: code, error_message: message)
+              end
+
+              self.class.deliveries << { to: to, body: body }
+              SmsTransport::Result.new(success?: true, error_code: nil, error_message: nil)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone_verification/sms_transport/adapters/log_adapter.rb
+++ b/app/services/command_tower/identity/phone_verification/sms_transport/adapters/log_adapter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Identity
+    module PhoneVerification
+      module SmsTransport
+        module Adapters
+          # Logs masked destination only — never OTP body in production logs.
+          class LogAdapter
+            def deliver(to:, body:)
+              Rails.logger.info(
+                {
+                  event: "phone_verification_sms_log_adapter",
+                  to_masked: mask_phone(to),
+                  body_length: body.to_s.length
+                }.to_json
+              )
+              SmsTransport::Result.new(success?: true, error_code: nil, error_message: nil)
+            end
+
+            private
+
+            def mask_phone(value)
+              digits = value.to_s.gsub(/\D/, "")
+              return "[redacted]" if digits.length < 4
+
+              "#{"*" * (digits.length - 4)}#{digits[-4,]}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/identity/phone_verification/sms_transport/adapters/twilio_adapter.rb
+++ b/app/services/command_tower/identity/phone_verification/sms_transport/adapters/twilio_adapter.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+
+module CommandTower
+  module Identity
+    module PhoneVerification
+      module SmsTransport
+        module Adapters
+          # Smallest Twilio REST adapter. Requires Twilio credentials via
+          # CredentialResolution and identity.phone_verification.sms_from (or TWILIO_FROM).
+          class TwilioAdapter
+            def deliver(to:, body:)
+              twilio = CredentialResolution.resolve(:twilio)
+              account_sid = twilio.account_sid
+              auth_token = twilio.auth_token
+              from = CommandTower.config.identity.phone_verification.sms_from.presence ||
+                ENV["TWILIO_FROM"].to_s.presence ||
+                ENV["TWILIO_FROM_NUMBER"].to_s.presence
+
+              if account_sid.blank? || auth_token.blank? || from.blank?
+                return SmsTransport::Result.new(
+                  success?: false,
+                  error_code: :configuration_unavailable,
+                  error_message: "SMS provider is not configured"
+                )
+              end
+
+              uri = URI("https://api.twilio.com/2010-04-01/Accounts/#{account_sid}/Messages.json")
+              request = Net::HTTP::Post.new(uri)
+              request.basic_auth(account_sid, auth_token)
+              request.set_form_data("To" => to, "From" => from, "Body" => body)
+
+              response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+                http.request(request)
+              end
+
+              if response.is_a?(Net::HTTPSuccess)
+                SmsTransport::Result.new(success?: true, error_code: nil, error_message: nil)
+              else
+                SmsTransport::Result.new(
+                  success?: false,
+                  error_code: :provider_unavailable,
+                  error_message: "SMS provider rejected the request"
+                )
+              end
+            rescue StandardError
+              SmsTransport::Result.new(
+                success?: false,
+                error_code: :provider_unavailable,
+                error_message: "SMS provider unavailable"
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/endpoints/pushover/verify.rb
+++ b/app/services/command_tower/messaging/endpoints/pushover/verify.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Endpoints
+      module Pushover
+        # Single verification authority for Pushover endpoints.
+        # begin → decrypt → validate.json → test messages.json → mark_verified | mark_verification_failed
+        class Verify
+          def self.call(owner_user_id:, endpoint_id:)
+            new(owner_user_id:, endpoint_id:).call
+          end
+
+          def initialize(owner_user_id:, endpoint_id:)
+            @owner_user_id = owner_user_id
+            @endpoint_id = endpoint_id
+          end
+
+          def call
+            record = load_active_pushover!
+            assert_adapter_enabled!
+
+            begin_verification_lifecycle!(record)
+            credentials = SecretReader.read_pushover_credentials!(
+              owner_user_id: @owner_user_id,
+              endpoint_id: @endpoint_id,
+            )
+
+            validate_result = Messaging::Pushover::Transport.validate_user!(
+              user_key: credentials.fetch(:user_key),
+              application_token: credentials.fetch(:application_token),
+            )
+            unless validate_result.success?
+              raise_after_failed!(validate_result)
+            end
+
+            config = CommandTower.config.messaging.pushover
+            test_result = Messaging::Pushover::Transport.send_test_notification!(
+              user_key: credentials.fetch(:user_key),
+              application_token: credentials.fetch(:application_token),
+              title: config.test_title,
+              message: config.test_message,
+            )
+            unless test_result.success?
+              raise_after_failed!(test_result)
+            end
+
+            MarkVerified.call(owner_user_id: @owner_user_id, endpoint_id: @endpoint_id)
+          end
+
+          private
+
+          def load_active_pushover!
+            record = Endpoint.for_owner(@owner_user_id).find_by(id: @endpoint_id)
+            raise NotFoundError, "endpoint not found" if record.nil?
+
+            ChannelGate.assert_record_supported!(record)
+            unless record.channel_key == "pushover"
+              raise ValidationError, "endpoint is not a pushover endpoint"
+            end
+            unless record.active?
+              raise ValidationError, "endpoint must be active to verify"
+            end
+            if record.pushover_credential.nil?
+              raise ValidationError, "pushover credentials are missing"
+            end
+
+            record
+          end
+
+          def assert_adapter_enabled!
+            adapter = CommandTower.config.messaging.pushover.adapter.to_s
+            return unless adapter == "disabled" || adapter.blank?
+
+            raise ValidationError, "Pushover verification adapter is disabled"
+          end
+
+          def begin_verification_lifecycle!(record)
+            case record.verification_state
+            when "pending"
+              nil
+            when "verified"
+              ResetVerification.call(owner_user_id: @owner_user_id, endpoint_id: @endpoint_id)
+              BeginVerification.call(owner_user_id: @owner_user_id, endpoint_id: @endpoint_id)
+            else
+              BeginVerification.call(owner_user_id: @owner_user_id, endpoint_id: @endpoint_id)
+            end
+          end
+
+          def raise_after_failed!(result)
+            MarkVerificationFailed.call(owner_user_id: @owner_user_id, endpoint_id: @endpoint_id)
+            raise VerificationFailedError.new(
+              error_code: result.error_code || :verification_failed,
+              message: result.error_message.presence || "Pushover verification failed",
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/endpoints/validators/pushover.rb
+++ b/app/services/command_tower/messaging/endpoints/validators/pushover.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Endpoints
+      module Validators
+        module Pushover
+          module_function
+
+          MIN_LENGTH = 8
+
+          # Legacy single-address path retained for model/spec helpers that still
+          # normalize a user key string — façade create/replace use credentials.
+          def validate!(address)
+            key = normalize_secret!(address, label: "pushover user key")
+            Result.new(
+              normalized_address: key,
+              masked_display_value: mask_user_key(key),
+            )
+          end
+
+          def validate_credentials!(credentials)
+            hash = coerce_credentials!(credentials)
+            user_key = normalize_secret!(hash[:user_key], label: "pushover user key")
+            application_token = normalize_secret!(
+              hash[:application_token],
+              label: "pushover application token",
+            )
+
+            PushoverCredentialsResult.new(
+              normalized_user_key: user_key,
+              normalized_application_token: application_token,
+              masked_display_value: mask_user_key(user_key),
+              pair_fingerprint_material: "#{user_key}\n#{application_token}",
+            )
+          end
+
+          def normalize_secret!(value, label:)
+            secret = value.to_s.strip
+            raise ValidationError, "#{label} must be present" if secret.empty?
+            raise ValidationError, "#{label} is too short" if secret.length < MIN_LENGTH
+
+            secret
+          end
+
+          def mask_user_key(key)
+            if key.length >= 4
+              "#{"•" * 8}#{key[-4, 4]}"
+            else
+              "configured"
+            end
+          end
+
+          def coerce_credentials!(credentials)
+            unless credentials.is_a?(Hash)
+              raise ValidationError, "pushover credentials must be a Hash with user_key and application_token"
+            end
+
+            {
+              user_key: credentials[:user_key] || credentials["user_key"],
+              application_token: credentials[:application_token] || credentials["application_token"],
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/execution/adapters/pushover/adapter.rb
+++ b/app/services/command_tower/messaging/execution/adapters/pushover/adapter.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Execution
+      module Adapters
+        module Pushover
+          # Execution adapter: decrypts credentials for the readiness-resolved
+          # endpoint and sends via Messaging::Pushover::Transport.
+          class Adapter
+            CREDENTIAL_REJECTION_CODES = %i[
+              invalid_user
+              invalid_token
+              invalid_credentials
+            ].freeze
+
+            def initialize(configuration: nil, transport: nil, secret_reader: nil)
+              @configuration = configuration || Configuration.new
+              @transport = transport || Messaging::Pushover::Transport
+              @secret_reader = secret_reader || Endpoints::SecretReader
+            end
+
+            def call(request:)
+              raise ArgumentError, "request must be an AdapterRequest" unless request.is_a?(AdapterRequest)
+
+              rendered = request.rendered
+              unless rendered.is_a?(Rendering::RenderedPushoverPayload)
+                return AdapterResult.build(outcome: :terminal_failure, error_code: "render_failed")
+              end
+
+              unless @configuration.pushover_configured?
+                return AdapterResult.build(outcome: :terminal_failure, error_code: "adapter_unconfigured")
+              end
+
+              endpoint_id = Integer(rendered.recipient_address, exception: false)
+              if endpoint_id.nil? || endpoint_id <= 0
+                return AdapterResult.build(outcome: :terminal_failure, error_code: "invalid_recipient")
+              end
+
+              delivery = Messaging::ChannelDelivery.includes(:communication).find_by(id: request.channel_delivery_id)
+              owner_user_id = delivery&.communication&.user_id
+              if owner_user_id.nil?
+                return AdapterResult.build(outcome: :terminal_failure, error_code: "recipient_missing")
+              end
+
+              credentials = read_credentials(owner_user_id:, endpoint_id:)
+              return credentials if credentials.is_a?(AdapterResult)
+
+              result = @transport.send_message!(
+                user_key: credentials.fetch(:user_key),
+                application_token: credentials.fetch(:application_token),
+                title: rendered.title,
+                message: rendered.message,
+              )
+              map_result(result, owner_user_id:, endpoint_id:)
+            rescue StandardError
+              AdapterResult.build(outcome: :retryable_failure, error_code: "pushover_transient")
+            end
+
+            private
+
+            def read_credentials(owner_user_id:, endpoint_id:)
+              @secret_reader.read_pushover_credentials!(owner_user_id:, endpoint_id:)
+            rescue Endpoints::NotFoundError, Endpoints::ValidationError
+              AdapterResult.build(outcome: :terminal_failure, error_code: "recipient_missing")
+            end
+
+            def map_result(result, owner_user_id:, endpoint_id:)
+              unless result.is_a?(Messaging::Pushover::Result)
+                return AdapterResult.build(outcome: :retryable_failure, error_code: "pushover_transient")
+              end
+
+              if result.success?
+                return AdapterResult.build(
+                  outcome: :success,
+                  normalized_provider_status: "accepted",
+                  provider_message_id: result.provider_request_id,
+                )
+              end
+
+              code = result.error_code.to_sym
+              if CREDENTIAL_REJECTION_CODES.include?(code)
+                mark_invalid_best_effort!(owner_user_id:, endpoint_id:)
+                return AdapterResult.build(outcome: :terminal_failure, error_code: "pushover_rejected")
+              end
+
+              case code
+              when :adapter_disabled
+                AdapterResult.build(outcome: :terminal_failure, error_code: "adapter_unconfigured")
+              when :timeout, :provider_unavailable, :rate_limited
+                AdapterResult.build(outcome: :retryable_failure, error_code: "pushover_transient")
+              else
+                AdapterResult.build(outcome: :retryable_failure, error_code: "pushover_transient")
+              end
+            end
+
+            def mark_invalid_best_effort!(owner_user_id:, endpoint_id:)
+              Endpoints.mark_invalid(owner_user_id:, endpoint_id:)
+            rescue StandardError
+              nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/execution/adapters/pushover/configuration.rb
+++ b/app/services/command_tower/messaging/execution/adapters/pushover/configuration.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Execution
+      module Adapters
+        module Pushover
+          # Platform readiness detector for Pushover delivery.
+          # User-owned credentials (no host app token). Ready when transport adapter
+          # is fake, log, or http — disabled never counts as platform_configured.
+          class Configuration
+            CONFIGURED_ADAPTERS = %w[fake log http].freeze
+
+            def self.pushover_configured?
+              new.pushover_configured?
+            end
+
+            def pushover_configured?
+              CONFIGURED_ADAPTERS.include?(adapter_name)
+            end
+
+            def adapter_name
+              CommandTower.config.messaging.pushover.adapter.to_s
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences.rb
+++ b/app/services/command_tower/messaging/preferences.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      module_function
+
+      def evaluate(
+        notification_type_key:,
+        recipient_id:,
+        preference_state: nil,
+        platform_enabled_channels: []
+      )
+        Evaluator.call(
+          notification_type_key:,
+          recipient_id:,
+          preference_state:,
+          platform_enabled_channels:,
+        )
+      end
+
+      def resolve(
+        notification_type_key:,
+        recipient_id:,
+        platform_enabled_channels: []
+      )
+        Resolve.call(
+          notification_type_key:,
+          recipient_id:,
+          platform_enabled_channels:,
+        )
+      end
+
+      def catalog(recipient_id:, platform_enabled_channels: [])
+        Catalog.call(
+          recipient_id:,
+          platform_enabled_channels:,
+        )
+      end
+
+      def find_stored(recipient_id:, notification_type_key:)
+        Store.find(recipient_id:, notification_type_key:)
+      end
+
+      def upsert_stored!(recipient_id:, notification_type_key:, preference_state:)
+        Store.upsert!(recipient_id:, notification_type_key:, preference_state:)
+      end
+
+      def delete_stored!(recipient_id:, notification_type_key:)
+        Store.delete!(recipient_id:, notification_type_key:)
+      end
+
+      def update(
+        recipient_id:,
+        notification_type_key:,
+        preference_state:,
+        platform_enabled_channels: []
+      )
+        Update.call(
+          recipient_id:,
+          notification_type_key:,
+          preference_state:,
+          platform_enabled_channels:,
+        )
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/catalog.rb
+++ b/app/services/command_tower/messaging/preferences/catalog.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Catalog
+        def self.call(...)
+          new(...).call
+        end
+
+        def initialize(recipient_id:, platform_enabled_channels: [])
+          @recipient_id = recipient_id
+          @platform_enabled_channels = Array(platform_enabled_channels).map(&:to_s).freeze
+        end
+
+        def call
+          recipient_ready_keys = recipient_ready_channel_keys
+          categories = []
+
+          NotificationTypes.catalog.each do |category|
+            notifications = []
+
+            category.declarations.each do |declaration|
+              next unless declaration.settings_visible
+
+              evaluation = Resolve.call(
+                notification_type_key: declaration.key,
+                recipient_id: @recipient_id,
+                platform_enabled_channels: @platform_enabled_channels,
+              )
+
+              notifications << build_notification(declaration, evaluation, recipient_ready_keys)
+            end
+
+            next if notifications.empty?
+
+            categories << ::CommandTower::Messaging::Preferences::CatalogCategoryResult.build(
+              key: category.key,
+              label: category.label,
+              description: nil,
+              order: category.order,
+              notifications:,
+            )
+          end
+
+          ::CommandTower::Messaging::Preferences::CatalogResult.build(categories:)
+        end
+
+        private
+
+        def recipient_ready_channel_keys
+          RecipientReadiness.for_recipient(
+            recipient_id: @recipient_id,
+            platform_enabled_channels: @platform_enabled_channels,
+          ).recipient_ready_channel_keys
+        rescue RecipientReadiness::RecipientNotFoundError
+          []
+        end
+
+        def build_notification(declaration, evaluation, recipient_ready_keys)
+          effective_state = evaluation.effective_preference_state || {}
+          effective_channels = effective_state["channels"] || {}
+          channels =
+            declaration.allowed_channels.to_h do |channel|
+              [channel, !!effective_channels[channel]]
+            end
+
+          inbox_enabled =
+            if effective_state.key?("inbox")
+              !!effective_state["inbox"]
+            else
+              evaluation.inbox_permitted
+            end
+
+          available =
+            declaration.allowed_channels & @platform_enabled_channels & recipient_ready_keys
+
+          ::CommandTower::Messaging::Preferences::CatalogNotificationResult.build(
+            key: declaration.key,
+            label: declaration.label,
+            description: declaration.description,
+            order: declaration.type_order,
+            configurable: declaration.user_configurable,
+            mandatory: declaration.mandatory,
+            inbox_available: declaration.inbox_available,
+            allowed_channels: declaration.allowed_channels,
+            available_channels: available,
+            inbox_enabled:,
+            channels:,
+            stored_override_present: evaluation.stored_override_present,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/catalog_category_result.rb
+++ b/app/services/command_tower/messaging/preferences/catalog_category_result.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      CatalogCategoryResult = Data.define(:key, :label, :description, :order, :notifications) do
+        def self.build(key:, label:, description:, order:, notifications:)
+          new(
+            key: key.to_s,
+            label: label.to_s,
+            description:,
+            order: Integer(order),
+            notifications: Array(notifications).freeze,
+          ).freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/catalog_notification_result.rb
+++ b/app/services/command_tower/messaging/preferences/catalog_notification_result.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      CatalogNotificationResult = Data.define(
+        :key,
+        :label,
+        :description,
+        :order,
+        :configurable,
+        :mandatory,
+        :inbox_available,
+        :allowed_channels,
+        :available_channels,
+        :inbox_enabled,
+        :channels,
+        :stored_override_present,
+      ) do
+        def self.build(
+          key:,
+          label:,
+          description:,
+          order:,
+          configurable:,
+          mandatory:,
+          inbox_available:,
+          allowed_channels:,
+          available_channels:,
+          inbox_enabled:,
+          channels:,
+          stored_override_present:
+        )
+          frozen_channels =
+            channels.to_h.transform_keys(&:to_s).transform_values { |value| !!value }.freeze
+
+          new(
+            key: key.to_s,
+            label: label.to_s,
+            description:,
+            order: Integer(order),
+            configurable: !!configurable,
+            mandatory: !!mandatory,
+            inbox_available: !!inbox_available,
+            allowed_channels: Array(allowed_channels).map(&:to_s).freeze,
+            available_channels: Array(available_channels).map(&:to_s).freeze,
+            inbox_enabled: !!inbox_enabled,
+            channels: frozen_channels,
+            stored_override_present: !!stored_override_present,
+          ).freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/catalog_result.rb
+++ b/app/services/command_tower/messaging/preferences/catalog_result.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      CatalogResult = Data.define(:categories) do
+        def self.build(categories:)
+          new(categories: Array(categories).freeze).freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/error.rb
+++ b/app/services/command_tower/messaging/preferences/error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Error < CommandTower::Error; end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/evaluation_result.rb
+++ b/app/services/command_tower/messaging/preferences/evaluation_result.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      EvaluationResult = Data.define(
+        :notification_type_key,
+        :recipient_id,
+        :permitted_channels,
+        :inbox_permitted,
+        :suppressed_destinations,
+        :mandatory,
+        :mandatory_enforced,
+        :stored_override_present,
+        :effective_preference_state,
+      ) do
+        def self.build(
+          notification_type_key:,
+          recipient_id:,
+          permitted_channels:,
+          inbox_permitted:,
+          suppressed_destinations:,
+          mandatory:,
+          mandatory_enforced:,
+          stored_override_present: false,
+          effective_preference_state: nil
+        )
+          new(
+            notification_type_key: notification_type_key.to_s,
+            recipient_id:,
+            permitted_channels: Array(permitted_channels).map(&:to_s).freeze,
+            inbox_permitted: !!inbox_permitted,
+            suppressed_destinations: Array(suppressed_destinations).freeze,
+            mandatory: !!mandatory,
+            mandatory_enforced: !!mandatory_enforced,
+            stored_override_present: !!stored_override_present,
+            effective_preference_state: freeze_effective_state(effective_preference_state),
+          ).freeze
+        end
+
+        def self.freeze_effective_state(state)
+          return nil if state.nil?
+
+          hash = state.to_h.transform_keys(&:to_s)
+          channels = hash["channels"]
+          frozen_channels =
+            if channels.nil?
+              {}.freeze
+            else
+              channels.to_h.transform_keys(&:to_s).transform_values { |value| !!value }.freeze
+            end
+
+          result = { "channels" => frozen_channels }
+          result["inbox"] = !!hash["inbox"] if hash.key?("inbox")
+          result.freeze
+        end
+        private_class_method :freeze_effective_state
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/evaluator.rb
+++ b/app/services/command_tower/messaging/preferences/evaluator.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Evaluator
+        def self.call(...)
+          new(...).call
+        end
+
+        def initialize(
+          notification_type_key:,
+          recipient_id:,
+          preference_state:,
+          platform_enabled_channels:
+        )
+          @notification_type_key = notification_type_key.to_s
+          @recipient_id = recipient_id
+          @raw_preference_state = preference_state
+          @platform_enabled_channels = Array(platform_enabled_channels).map(&:to_s).freeze
+        end
+
+        def call
+          declaration = lookup_declaration!
+          defaults = PreferenceState.from_declaration_default(declaration.default_preference_state)
+          recipient_override = PreferenceState.normalize(@raw_preference_state)
+
+          effective =
+            if declaration.user_configurable && recipient_override
+              recipient_override.merge_over(defaults)
+            else
+              defaults
+            end
+
+          permitted = []
+          suppressed = []
+
+          declaration.allowed_channels.each do |channel|
+            if !@platform_enabled_channels.include?(channel)
+              suppressed << SuppressedDestination.build(
+                destination: channel,
+                reason_class: ReasonClasses::SKIPPED_BY_POLICY,
+              )
+              next
+            end
+
+            if declaration.user_configurable && !effective.channel_enabled?(channel, default: true)
+              suppressed << SuppressedDestination.build(
+                destination: channel,
+                reason_class: ReasonClasses::SUPPRESSED_BY_PREFERENCE,
+              )
+              next
+            end
+
+            # Not user-configurable: preference opt-outs ignored; still require default enablement
+            if !declaration.user_configurable && !effective.channel_enabled?(channel, default: true)
+              suppressed << SuppressedDestination.build(
+                destination: channel,
+                reason_class: ReasonClasses::SKIPPED_BY_POLICY,
+              )
+              next
+            end
+
+            permitted << channel
+          end
+
+          extras = effective.channels.keys - declaration.allowed_channels
+          extras.each do |channel|
+            suppressed << SuppressedDestination.build(
+              destination: channel,
+              reason_class: ReasonClasses::SKIPPED_BY_POLICY,
+            )
+          end
+
+          inbox_permitted, inbox_suppressed = evaluate_inbox(declaration, effective)
+          suppressed.concat(inbox_suppressed)
+
+          mandatory_enforced = false
+          if declaration.mandatory
+            permitted, suppressed, inbox_permitted, mandatory_enforced =
+              enforce_mandatory(
+                declaration:,
+                defaults:,
+                permitted:,
+                suppressed:,
+                inbox_permitted:,
+              )
+          end
+
+          EvaluationResult.build(
+            notification_type_key: @notification_type_key,
+            recipient_id: @recipient_id,
+            permitted_channels: permitted.uniq,
+            inbox_permitted:,
+            suppressed_destinations: suppressed,
+            mandatory: declaration.mandatory,
+            mandatory_enforced:,
+            stored_override_present: false,
+            effective_preference_state: effective.to_raw_hash,
+          )
+        end
+
+        private
+
+        def lookup_declaration!
+          NotificationTypes.lookup(@notification_type_key)
+        rescue NotificationTypes::NotFoundError
+          raise UnknownTypeError, "notification type not registered: #{@notification_type_key}"
+        end
+
+        def evaluate_inbox(declaration, effective)
+          unless declaration.inbox_available
+            return [false, []]
+          end
+
+          enabled =
+            if effective.inbox.nil?
+              true
+            else
+              effective.inbox
+            end
+
+          if declaration.user_configurable && !enabled
+            return [
+              false,
+              [
+                SuppressedDestination.build(
+                  destination: :inbox,
+                  reason_class: ReasonClasses::SUPPRESSED_BY_PREFERENCE,
+                ),
+              ],
+            ]
+          end
+
+          if !declaration.user_configurable && !enabled
+            return [
+              false,
+              [
+                SuppressedDestination.build(
+                  destination: :inbox,
+                  reason_class: ReasonClasses::SKIPPED_BY_POLICY,
+                ),
+              ],
+            ]
+          end
+
+          [true, []]
+        end
+
+        def enforce_mandatory(declaration:, defaults:, permitted:, suppressed:, inbox_permitted:)
+          required_channels = declaration.default_channels & declaration.allowed_channels
+          required_inbox = declaration.inbox_available && defaults.inbox != false
+
+          enforced = false
+          permitted = permitted.dup
+          suppressed = suppressed.reject do |item|
+            next false unless item.reason_class == ReasonClasses::SUPPRESSED_BY_PREFERENCE
+
+            if item.destination == :inbox
+              next false unless required_inbox
+
+              enforced = true
+              true
+            elsif required_channels.include?(item.destination)
+              enforced = true
+              true
+            else
+              false
+            end
+          end
+
+          required_channels.each do |channel|
+            next if permitted.include?(channel)
+            next unless @platform_enabled_channels.include?(channel)
+
+            permitted << channel
+            enforced = true
+            suppressed.reject! do |item|
+              item.destination == channel && item.reason_class == ReasonClasses::SUPPRESSED_BY_PREFERENCE
+            end
+          end
+
+          if required_inbox && !inbox_permitted
+            inbox_permitted = true
+            enforced = true
+            suppressed.reject! { |item| item.destination == :inbox }
+          end
+
+          [permitted, suppressed, inbox_permitted, enforced]
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/invalid_preference_state_error.rb
+++ b/app/services/command_tower/messaging/preferences/invalid_preference_state_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class InvalidPreferenceStateError < Error; end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/invalid_preference_write_error.rb
+++ b/app/services/command_tower/messaging/preferences/invalid_preference_write_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class InvalidPreferenceWriteError < Error
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/not_settings_visible_error.rb
+++ b/app/services/command_tower/messaging/preferences/not_settings_visible_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class NotSettingsVisibleError < Error
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/preference_state.rb
+++ b/app/services/command_tower/messaging/preferences/preference_state.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      PreferenceState = Data.define(:channels, :inbox) do
+        def self.normalize(raw)
+          return nil if raw.nil?
+
+          unless raw.respond_to?(:to_h)
+            raise InvalidPreferenceStateError, "preference_state must be a hash-like object"
+          end
+
+          hash = raw.to_h.transform_keys(&:to_s)
+
+          if hash.empty?
+            return nil
+          end
+
+          channels_raw = hash["channels"]
+          channels =
+            if channels_raw.nil?
+              {}.freeze
+            else
+              unless channels_raw.respond_to?(:to_h)
+                raise InvalidPreferenceStateError, "preference_state channels must be a hash-like object"
+              end
+
+              channels_raw.to_h.transform_keys(&:to_s).transform_values { |value| !!value }.freeze
+            end
+
+          inbox = hash.key?("inbox") ? !!hash["inbox"] : nil
+
+          new(channels:, inbox:).freeze
+        end
+
+        def self.from_declaration_default(default_preference_state)
+          normalize(default_preference_state) || new(channels: {}.freeze, inbox: nil).freeze
+        end
+
+        def merge_over(base)
+          merged_channels = base.channels.merge(channels)
+          merged_inbox = inbox.nil? ? base.inbox : inbox
+          self.class.new(channels: merged_channels.freeze, inbox: merged_inbox).freeze
+        end
+
+        def channel_enabled?(channel_key, default: true)
+          return default unless channels.key?(channel_key)
+
+          channels.fetch(channel_key)
+        end
+
+        def to_raw_hash
+          hash = { "channels" => channels.to_h }
+          hash["inbox"] = inbox unless inbox.nil?
+          hash
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/reason_classes.rb
+++ b/app/services/command_tower/messaging/preferences/reason_classes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      module ReasonClasses
+        SUPPRESSED_BY_PREFERENCE = "suppressed_by_preference"
+        SKIPPED_BY_POLICY = "skipped_by_policy"
+
+        ALL = [
+          SUPPRESSED_BY_PREFERENCE,
+          SKIPPED_BY_POLICY,
+        ].freeze
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/resolve.rb
+++ b/app/services/command_tower/messaging/preferences/resolve.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Resolve
+        def self.call(...)
+          new(...).call
+        end
+
+        def initialize(
+          notification_type_key:,
+          recipient_id:,
+          platform_enabled_channels: []
+        )
+          @notification_type_key = notification_type_key.to_s
+          @recipient_id = recipient_id
+          @platform_enabled_channels = platform_enabled_channels
+        end
+
+        def call
+          stored = Store.find(
+            recipient_id: @recipient_id,
+            notification_type_key: @notification_type_key,
+          )
+          raw_override = stored&.to_raw_hash
+
+          evaluation = Evaluator.call(
+            notification_type_key: @notification_type_key,
+            recipient_id: @recipient_id,
+            preference_state: raw_override,
+            platform_enabled_channels: @platform_enabled_channels,
+          )
+
+          EvaluationResult.build(
+            notification_type_key: evaluation.notification_type_key,
+            recipient_id: evaluation.recipient_id,
+            permitted_channels: evaluation.permitted_channels,
+            inbox_permitted: evaluation.inbox_permitted,
+            suppressed_destinations: evaluation.suppressed_destinations,
+            mandatory: evaluation.mandatory,
+            mandatory_enforced: evaluation.mandatory_enforced,
+            stored_override_present: !stored.nil?,
+            effective_preference_state: evaluation.effective_preference_state,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/store.rb
+++ b/app/services/command_tower/messaging/preferences/store.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Store
+        def self.find(recipient_id:, notification_type_key:)
+          new.find(recipient_id:, notification_type_key:)
+        end
+
+        def self.upsert!(recipient_id:, notification_type_key:, preference_state:)
+          new.upsert!(recipient_id:, notification_type_key:, preference_state:)
+        end
+
+        def self.delete!(recipient_id:, notification_type_key:)
+          new.delete!(recipient_id:, notification_type_key:)
+        end
+
+        def find(recipient_id:, notification_type_key:)
+          record = Messaging::NotificationPreference.find_for(
+            recipient_id:,
+            notification_type_key:,
+          )
+          return nil if record.nil?
+
+          PreferenceState.normalize(record.state)
+        rescue ActiveRecord::ActiveRecordError => error
+          raise StoreError, "failed to load notification preference: #{error.message}"
+        rescue InvalidPreferenceStateError
+          raise
+        end
+
+        def upsert!(recipient_id:, notification_type_key:, preference_state:)
+          key = notification_type_key.to_s
+          declaration = lookup_declaration!(key)
+          validate_writable!(declaration)
+
+          normalized = PreferenceState.normalize(preference_state)
+          if normalized.nil?
+            raise InvalidPreferenceWriteError, "preference_state must be present"
+          end
+
+          validate_channels!(declaration, normalized)
+          validate_inbox!(declaration, normalized)
+
+          persist!(recipient_id:, notification_type_key: key, state: normalized.to_raw_hash)
+          normalized
+        rescue ActiveRecord::ActiveRecordError => error
+          raise StoreError, "failed to persist notification preference: #{error.message}"
+        end
+
+        def delete!(recipient_id:, notification_type_key:)
+          key = notification_type_key.to_s
+          record = Messaging::NotificationPreference.find_for(
+            recipient_id:,
+            notification_type_key: key,
+          )
+          return if record.nil?
+
+          record.destroy!
+          nil
+        rescue ActiveRecord::ActiveRecordError => error
+          raise StoreError, "failed to delete notification preference: #{error.message}"
+        end
+
+        private
+
+        def lookup_declaration!(key)
+          NotificationTypes.lookup(key)
+        rescue NotificationTypes::NotFoundError
+          raise UnknownTypeError, "notification type not registered: #{key}"
+        end
+
+        def validate_writable!(declaration)
+          return if declaration.user_configurable
+
+          raise InvalidPreferenceWriteError,
+                "notification type is not user-configurable: #{declaration.key}"
+        end
+
+        def validate_channels!(declaration, normalized)
+          extras = normalized.channels.keys - declaration.allowed_channels
+          return if extras.empty?
+
+          raise InvalidPreferenceWriteError,
+                "preference channels outside allowed set: #{extras.join(', ')}"
+        end
+
+        def validate_inbox!(declaration, normalized)
+          return if normalized.inbox.nil?
+          return if declaration.inbox_available
+
+          raise InvalidPreferenceWriteError,
+                "inbox preference is not available for notification type: #{declaration.key}"
+        end
+
+        def persist!(recipient_id:, notification_type_key:, state:)
+          record = Messaging::NotificationPreference.find_for(
+            recipient_id:,
+            notification_type_key:,
+          )
+
+          if record.nil?
+            begin
+              Messaging::NotificationPreference.create!(
+                user_id: recipient_id,
+                notification_type_key:,
+                state:,
+              )
+            rescue ActiveRecord::RecordNotUnique
+              record = Messaging::NotificationPreference.find_for(
+                recipient_id:,
+                notification_type_key:,
+              )
+              raise StoreError, "failed to persist notification preference" if record.nil?
+
+              record.update!(state:)
+            end
+          else
+            record.update!(state:)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/store_error.rb
+++ b/app/services/command_tower/messaging/preferences/store_error.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class StoreError < Error
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/suppressed_destination.rb
+++ b/app/services/command_tower/messaging/preferences/suppressed_destination.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      SuppressedDestination = Data.define(:destination, :reason_class) do
+        def self.build(destination:, reason_class:)
+          unless ReasonClasses::ALL.include?(reason_class)
+            raise ArgumentError, "unknown reason_class: #{reason_class}"
+          end
+
+          dest =
+            if destination == :inbox || destination == "inbox"
+              :inbox
+            else
+              destination.to_s
+            end
+
+          new(destination: dest, reason_class:).freeze
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/unknown_type_error.rb
+++ b/app/services/command_tower/messaging/preferences/unknown_type_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class UnknownTypeError < Error; end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/preferences/update.rb
+++ b/app/services/command_tower/messaging/preferences/update.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Preferences
+      class Update
+        def self.call(...)
+          new(...).call
+        end
+
+        def initialize(
+          recipient_id:,
+          notification_type_key:,
+          preference_state:,
+          platform_enabled_channels: []
+        )
+          @recipient_id = recipient_id
+          @notification_type_key = notification_type_key.to_s
+          @preference_state = preference_state
+          @platform_enabled_channels = Array(platform_enabled_channels).map(&:to_s).freeze
+        end
+
+        def call
+          declaration = lookup_declaration!
+          validate_settings_visible!(declaration)
+          validate_writable!(declaration)
+
+          if reset_request?
+            persist_reset!
+          else
+            candidate = build_candidate_state!(declaration)
+            sparse = sparsify(declaration, candidate)
+            persist_sparse!(sparse)
+          end
+
+          evaluation = Resolve.call(
+            notification_type_key: @notification_type_key,
+            recipient_id: @recipient_id,
+            platform_enabled_channels: @platform_enabled_channels,
+          )
+
+          build_notification_result(declaration, evaluation, recipient_ready_channel_keys)
+        end
+
+        private
+
+        def recipient_ready_channel_keys
+          RecipientReadiness.for_recipient(
+            recipient_id: @recipient_id,
+            platform_enabled_channels: @platform_enabled_channels,
+          ).recipient_ready_channel_keys
+        rescue RecipientReadiness::RecipientNotFoundError
+          []
+        end
+
+        def lookup_declaration!
+          NotificationTypes.lookup(@notification_type_key)
+        rescue NotificationTypes::NotFoundError
+          raise UnknownTypeError, "notification type not registered: #{@notification_type_key}"
+        end
+
+        def validate_settings_visible!(declaration)
+          return if declaration.settings_visible
+
+          raise NotSettingsVisibleError,
+                "notification type is not settings-visible: #{declaration.key}"
+        end
+
+        def validate_writable!(declaration)
+          return if declaration.user_configurable
+
+          raise InvalidPreferenceWriteError,
+                "notification type is not user-configurable: #{declaration.key}"
+        end
+
+        def reset_request?
+          return true if @preference_state.nil?
+
+          @preference_state.respond_to?(:to_h) && @preference_state.to_h.empty?
+        end
+
+        def build_candidate_state!(declaration)
+          unless @preference_state.respond_to?(:to_h)
+            raise InvalidPreferenceStateError, "preference_state must be a hash-like object"
+          end
+
+          hash = @preference_state.to_h.transform_keys(&:to_s)
+          unknown_keys = hash.keys - %w[channels inbox]
+          if unknown_keys.any?
+            raise InvalidPreferenceWriteError,
+                  "unsupported preference keys: #{unknown_keys.join(', ')}"
+          end
+
+          channels = parse_channels!(declaration, hash["channels"])
+          inbox = parse_inbox!(declaration, hash)
+
+          PreferenceState.new(channels: channels.freeze, inbox:).freeze
+        end
+
+        def parse_channels!(declaration, channels_raw)
+          return {}.freeze if channels_raw.nil?
+
+          unless channels_raw.respond_to?(:to_h)
+            raise InvalidPreferenceStateError, "preference_state channels must be a hash-like object"
+          end
+
+          channels = {}
+          channels_raw.to_h.each do |raw_key, raw_value|
+            key = raw_key.to_s
+            unless declaration.allowed_channels.include?(key)
+              raise InvalidPreferenceWriteError,
+                    "preference channels outside allowed set: #{key}"
+            end
+            unless [true, false].include?(raw_value)
+              raise InvalidPreferenceStateError,
+                    "preference channel values must be boolean: #{key}"
+            end
+
+            channels[key] = raw_value
+          end
+          channels
+        end
+
+        def parse_inbox!(declaration, hash)
+          return nil unless hash.key?("inbox")
+
+          unless [true, false].include?(hash["inbox"])
+            raise InvalidPreferenceStateError, "preference inbox must be a boolean"
+          end
+
+          unless declaration.inbox_available
+            raise InvalidPreferenceWriteError,
+                  "inbox preference is not available for notification type: #{declaration.key}"
+          end
+
+          hash["inbox"]
+        end
+
+        def sparsify(declaration, candidate)
+          defaults = PreferenceState.from_declaration_default(declaration.default_preference_state)
+          sparse_channels = {}
+
+          candidate.channels.each do |channel, enabled|
+            default_enabled = defaults.channel_enabled?(channel, default: true)
+            sparse_channels[channel] = enabled unless enabled == default_enabled
+          end
+
+          sparse_inbox =
+            if candidate.inbox.nil?
+              nil
+            elsif candidate.inbox == defaults.inbox
+              nil
+            else
+              candidate.inbox
+            end
+
+          return nil if sparse_channels.empty? && sparse_inbox.nil?
+
+          PreferenceState.new(channels: sparse_channels.freeze, inbox: sparse_inbox).freeze
+        end
+
+        def persist_reset!
+          current = Store.find(
+            recipient_id: @recipient_id,
+            notification_type_key: @notification_type_key,
+          )
+          return if current.nil?
+
+          ActiveRecord::Base.transaction do
+            Store.delete!(
+              recipient_id: @recipient_id,
+              notification_type_key: @notification_type_key,
+            )
+          end
+        end
+
+        def persist_sparse!(sparse)
+          current = Store.find(
+            recipient_id: @recipient_id,
+            notification_type_key: @notification_type_key,
+          )
+
+          if sparse.nil?
+            return if current.nil?
+
+            ActiveRecord::Base.transaction do
+              Store.delete!(
+                recipient_id: @recipient_id,
+                notification_type_key: @notification_type_key,
+              )
+            end
+            return
+          end
+
+          return if same_stored_state?(current, sparse)
+
+          ActiveRecord::Base.transaction do
+            Store.upsert!(
+              recipient_id: @recipient_id,
+              notification_type_key: @notification_type_key,
+              preference_state: sparse.to_raw_hash,
+            )
+          end
+        end
+
+        def same_stored_state?(current, sparse)
+          return false if current.nil?
+
+          current.to_raw_hash == sparse.to_raw_hash
+        end
+
+        def build_notification_result(declaration, evaluation, recipient_ready_keys)
+          effective_state = evaluation.effective_preference_state || {}
+          effective_channels = effective_state["channels"] || {}
+          channels =
+            declaration.allowed_channels.to_h do |channel|
+              [channel, !!effective_channels[channel]]
+            end
+
+          inbox_enabled =
+            if effective_state.key?("inbox")
+              !!effective_state["inbox"]
+            else
+              evaluation.inbox_permitted
+            end
+
+          available =
+            declaration.allowed_channels & @platform_enabled_channels & recipient_ready_keys
+
+          ::CommandTower::Messaging::Preferences::CatalogNotificationResult.build(
+            key: declaration.key,
+            label: declaration.label,
+            description: declaration.description,
+            order: declaration.type_order,
+            configurable: declaration.user_configurable,
+            mandatory: declaration.mandatory,
+            inbox_available: declaration.inbox_available,
+            allowed_channels: declaration.allowed_channels,
+            available_channels: available,
+            inbox_enabled:,
+            channels:,
+            stored_override_present: evaluation.stored_override_present,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/adapters/disabled_adapter.rb
+++ b/app/services/command_tower/messaging/pushover/adapters/disabled_adapter.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Pushover
+      module Adapters
+        # Fail-closed default. Never contacts the provider.
+        class DisabledAdapter
+          def validate_user!(user_key:, application_token:)
+            Result.failure(
+              error_code: :adapter_disabled,
+              error_message: "Pushover verification adapter is disabled",
+            )
+          end
+
+          def send_test_notification!(user_key:, application_token:, title:, message:)
+            Result.failure(
+              error_code: :adapter_disabled,
+              error_message: "Pushover verification adapter is disabled",
+            )
+          end
+
+          def send_message!(user_key:, application_token:, title:, message:)
+            Result.failure(
+              error_code: :adapter_disabled,
+              error_message: "Pushover delivery adapter is disabled",
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/adapters/fake_adapter.rb
+++ b/app/services/command_tower/messaging/pushover/adapters/fake_adapter.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Pushover
+      module Adapters
+        # In-memory / no-network adapter for tests and local development.
+        # Inject failures via FakeAdapter.fail_with = :invalid_user | :invalid_token |
+        # :invalid_credentials | :timeout | :provider_unavailable | :rate_limited
+        class FakeAdapter
+          class << self
+            attr_accessor :validations, :test_notifications, :messages, :fail_with
+
+            def reset!
+              self.validations = []
+              self.test_notifications = []
+              self.messages = []
+              self.fail_with = nil
+            end
+          end
+
+          self.reset!
+
+          def validate_user!(user_key:, application_token:)
+            failure = injected_failure
+            return failure if failure
+
+            self.class.validations << {
+              user_key_present: user_key.to_s.present?,
+              application_token_present: application_token.to_s.present?,
+            }
+            Result.ok
+          end
+
+          def send_test_notification!(user_key:, application_token:, title:, message:)
+            failure = injected_failure
+            return failure if failure
+
+            self.class.test_notifications << {
+              user_key_present: user_key.to_s.present?,
+              application_token_present: application_token.to_s.present?,
+              title: title.to_s,
+              message: message.to_s,
+            }
+            Result.ok
+          end
+
+          def send_message!(user_key:, application_token:, title:, message:)
+            failure = injected_failure
+            return failure if failure
+
+            self.class.messages << {
+              user_key_present: user_key.to_s.present?,
+              application_token_present: application_token.to_s.present?,
+              title: title.to_s,
+              message: message.to_s,
+            }
+            Result.ok(provider_request_id: "fake-request-#{self.class.messages.size}")
+          end
+
+          private
+
+          def injected_failure
+            case self.class.fail_with
+            when :invalid_user
+              Result.failure(error_code: :invalid_user, error_message: "Pushover user key is invalid")
+            when :invalid_token
+              Result.failure(error_code: :invalid_token, error_message: "Pushover application token is invalid")
+            when :invalid_credentials
+              Result.failure(error_code: :invalid_credentials, error_message: "Pushover credentials were rejected")
+            when :timeout
+              Result.failure(error_code: :timeout, error_message: "Pushover provider timed out")
+            when :provider_unavailable
+              Result.failure(error_code: :provider_unavailable, error_message: "Pushover provider unavailable")
+            when :rate_limited
+              Result.failure(error_code: :rate_limited, error_message: "Pushover provider rate limited the request")
+            when NilClass
+              nil
+            else
+              Result.failure(
+                error_code: self.class.fail_with.to_sym,
+                error_message: "Pushover provider rejected the request",
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/adapters/http_adapter.rb
+++ b/app/services/command_tower/messaging/pushover/adapters/http_adapter.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+require "uri"
+
+module CommandTower
+  module Messaging
+    module Pushover
+      module Adapters
+        # Real Pushover HTTP client for credential validation, test notifications,
+        # and production delivery. Never returns or logs secrets / raw provider payloads.
+        class HttpAdapter
+          def validate_user!(user_key:, application_token:)
+            post_form(
+              path: "users/validate.json",
+              form: {
+                "token" => application_token.to_s,
+                "user" => user_key.to_s,
+              },
+            )
+          end
+
+          def send_test_notification!(user_key:, application_token:, title:, message:)
+            post_form(
+              path: "messages.json",
+              form: {
+                "token" => application_token.to_s,
+                "user" => user_key.to_s,
+                "title" => title.to_s,
+                "message" => message.to_s,
+              },
+            )
+          end
+
+          def send_message!(user_key:, application_token:, title:, message:)
+            post_form(
+              path: "messages.json",
+              form: {
+                "token" => application_token.to_s,
+                "user" => user_key.to_s,
+                "title" => title.to_s,
+                "message" => message.to_s,
+              },
+            )
+          end
+
+          private
+
+          def post_form(path:, form:)
+            config = CommandTower.config.messaging.pushover
+            uri = URI.join("#{config.api_base_url.to_s.chomp('/')}/", path)
+            timeout = config.timeout_seconds.to_i
+            timeout = 5 if timeout <= 0
+
+            request = Net::HTTP::Post.new(uri)
+            request.set_form_data(form)
+
+            response = Net::HTTP.start(
+              uri.hostname,
+              uri.port,
+              use_ssl: uri.scheme == "https",
+              open_timeout: timeout,
+              read_timeout: timeout,
+            ) do |http|
+              http.request(request)
+            end
+
+            classify_response(response)
+          rescue Net::OpenTimeout, Net::ReadTimeout
+            Result.failure(error_code: :timeout, error_message: "Pushover provider timed out")
+          rescue StandardError
+            Result.failure(error_code: :provider_unavailable, error_message: "Pushover provider unavailable")
+          end
+
+          def classify_response(response)
+            status = response.code.to_i
+            body = parse_json(response.body)
+            status_ok = body.is_a?(Hash) && body["status"].to_i == 1
+            request_id = body.is_a?(Hash) ? body["request"].to_s.presence : nil
+
+            if response.is_a?(Net::HTTPSuccess) && status_ok
+              return Result.ok(provider_request_id: request_id)
+            end
+
+            errors = Array(body.is_a?(Hash) ? body["errors"] : nil).map(&:to_s)
+            joined = errors.join(" ").downcase
+
+            if status == 429
+              return Result.failure(
+                error_code: :rate_limited,
+                error_message: "Pushover provider rate limited the request",
+                provider_request_id: request_id,
+              )
+            end
+
+            if joined.include?("application token") || joined.include?("app token") || joined.include?("invalid token")
+              return Result.failure(
+                error_code: :invalid_token,
+                error_message: "Pushover application token is invalid",
+                provider_request_id: request_id,
+              )
+            end
+
+            if joined.include?("user key") || joined.include?("user is invalid") || joined.include?("user key is invalid")
+              return Result.failure(
+                error_code: :invalid_user,
+                error_message: "Pushover user key is invalid",
+                provider_request_id: request_id,
+              )
+            end
+
+            if status == 400
+              return Result.failure(
+                error_code: :invalid_credentials,
+                error_message: "Pushover credentials were rejected",
+                provider_request_id: request_id,
+              )
+            end
+
+            if status >= 500
+              return Result.failure(
+                error_code: :provider_unavailable,
+                error_message: "Pushover provider unavailable",
+                provider_request_id: request_id,
+              )
+            end
+
+            Result.failure(
+              error_code: :provider_unavailable,
+              error_message: "Pushover provider rejected the request",
+              provider_request_id: request_id,
+            )
+          end
+
+          def parse_json(body)
+            JSON.parse(body.to_s)
+          rescue JSON::ParserError
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/adapters/log_adapter.rb
+++ b/app/services/command_tower/messaging/pushover/adapters/log_adapter.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Pushover
+      module Adapters
+        # Dev-only log adapter. Emits safe metadata only; never secrets.
+        class LogAdapter
+          def validate_user!(user_key:, application_token:)
+            Rails.logger.info(
+              {
+                component: "command_tower.messaging",
+                event: "messaging.pushover.log_adapter.validate_user",
+                user_key_length: user_key.to_s.length,
+                application_token_length: application_token.to_s.length,
+              }.to_json,
+            )
+            Result.ok
+          end
+
+          def send_test_notification!(user_key:, application_token:, title:, message:)
+            Rails.logger.info(
+              {
+                component: "command_tower.messaging",
+                event: "messaging.pushover.log_adapter.send_test_notification",
+                user_key_length: user_key.to_s.length,
+                application_token_length: application_token.to_s.length,
+                title_length: title.to_s.length,
+                message_length: message.to_s.length,
+              }.to_json,
+            )
+            Result.ok
+          end
+
+          def send_message!(user_key:, application_token:, title:, message:)
+            Rails.logger.info(
+              {
+                component: "command_tower.messaging",
+                event: "messaging.pushover.log_adapter.send_message",
+                user_key_length: user_key.to_s.length,
+                application_token_length: application_token.to_s.length,
+                title_length: title.to_s.length,
+                message_length: message.to_s.length,
+              }.to_json,
+            )
+            Result.ok(provider_request_id: "log-message")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/result.rb
+++ b/app/services/command_tower/messaging/pushover/result.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Pushover
+      # Provider-call result. Never includes secrets or raw provider payloads.
+      Result = Struct.new(
+        :success?,
+        :error_code,
+        :error_message,
+        :provider_request_id,
+        keyword_init: true,
+      ) do
+        def self.ok(provider_request_id: nil)
+          new(
+            success?: true,
+            error_code: nil,
+            error_message: nil,
+            provider_request_id: provider_request_id&.to_s.presence,
+          )
+        end
+
+        def self.failure(error_code:, error_message:, provider_request_id: nil)
+          new(
+            success?: false,
+            error_code: error_code.to_sym,
+            error_message: error_message.to_s,
+            provider_request_id: provider_request_id&.to_s.presence,
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/pushover/transport.rb
+++ b/app/services/command_tower/messaging/pushover/transport.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Pushover
+      # Selects Pushover provider transport from config. Provider ops only —
+      # verification and delivery. Does not query endpoints, preferences, or
+      # create DeliveryAttempts.
+      module Transport
+        class << self
+          attr_writer :adapter
+
+          def adapter
+            @adapter ||= build_adapter
+          end
+
+          def reset_adapter!
+            @adapter = nil
+          end
+
+          def validate_user!(user_key:, application_token:)
+            adapter.validate_user!(user_key:, application_token:)
+          end
+
+          def send_test_notification!(user_key:, application_token:, title:, message:)
+            adapter.send_test_notification!(
+              user_key:,
+              application_token:,
+              title:,
+              message:,
+            )
+          end
+
+          def send_message!(user_key:, application_token:, title:, message:)
+            adapter.send_message!(
+              user_key:,
+              application_token:,
+              title:,
+              message:,
+            )
+          end
+
+          private
+
+          def build_adapter
+            name = CommandTower.config.messaging.pushover.adapter.to_s
+            case name
+            when "fake"
+              Adapters::FakeAdapter.new
+            when "log"
+              Adapters::LogAdapter.new
+            when "http"
+              Adapters::HttpAdapter.new
+            when "disabled"
+              Adapters::DisabledAdapter.new
+            else
+              Adapters::DisabledAdapter.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/messaging/rendering/rendered_pushover_payload.rb
+++ b/app/services/command_tower/messaging/rendering/rendered_pushover_payload.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Messaging
+    module Rendering
+      # Provider-neutral Pushover rendered payload. recipient_address is the opaque
+      # endpoint id resolved by RecipientReadiness — never credentials.
+      RenderedPushoverPayload = Data.define(
+        :recipient_address,
+        :title,
+        :message,
+      ) do
+        def self.build(recipient_address:, title:, message:)
+          values = [recipient_address, title, message]
+          raise ArgumentError, "arbitrary hashes are not accepted" if values.any? { |v| v.is_a?(Hash) }
+          raise ArgumentError, "ActiveRecord objects are not accepted" if values.any? { |v| active_record_like?(v) }
+          raise ArgumentError, "raw exception objects are not accepted" if values.any? { |v| v.is_a?(Exception) }
+
+          validate_required_string!(recipient_address, "recipient_address")
+          validate_required_string!(title, "title")
+          validate_required_string!(message, "message")
+
+          new(
+            recipient_address:,
+            title:,
+            message:,
+          ).freeze
+        end
+
+        def self.validate_required_string!(value, field_name)
+          raise ArgumentError, "#{field_name} is required" if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+          raise ArgumentError, "#{field_name} must be a String" unless value.is_a?(String)
+        end
+        private_class_method :validate_required_string!
+
+        def self.active_record_like?(value)
+          defined?(ActiveRecord::Base) && value.is_a?(ActiveRecord::Base)
+        end
+        private_class_method :active_record_like?
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/phone_verification/send.rb
+++ b/app/services/command_tower/services/account/phone_verification/send.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module PhoneVerification
+        # Issues a one-time phone verification code and delivers it over SMS.
+        class Send < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+
+          def call
+            send_unavailable! unless configuration.enable
+
+            phone = user.phone_number.to_s.strip
+            phone_missing! if phone.blank?
+            already_verified! if user.phone_number_validated
+
+            enforce_resend_cooldown!
+
+            issued = issue_code(phone)
+            deliver(phone, issued.secret)
+
+            context.code_length = configuration.verify_code_length
+            context.expires_at = issued.record.death_time
+            context.phone_number = phone
+            context.resend_available_at = Time.current + configuration.resend_cooldown
+          end
+
+          private
+
+          def configuration
+            CommandTower.config.identity.phone_verification
+          end
+
+          def enforce_resend_cooldown!
+            cooldown = configuration.resend_cooldown
+            return if cooldown.nil? || cooldown <= 0.seconds
+
+            latest = UserSecret
+              .where(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION)
+              .order(created_at: :desc)
+              .first
+            return if latest.nil?
+
+            available_at = latest.created_at + cooldown
+            return if Time.current >= available_at
+
+            context.fail!(
+              application_error: CommandTower::Errors::Account::PhoneVerificationThrottledError.new(
+                resend_available_at: available_at
+              )
+            )
+          end
+
+          def issue_code(phone)
+            result = CommandTower::Secrets::Generate.(
+              user:,
+              secret_length: configuration.verify_code_length,
+              reason: CommandTower::Secrets::PHONE_VERIFICATION,
+              type: CommandTower::Secrets::NUMERIC,
+              use_count_max: 1,
+              death_time: configuration.verify_code_valid_for,
+              extra: phone,
+              cleanse: true
+            )
+
+            if result.failure?
+              log_error("Unable to issue a phone verification code for user [#{user.id}]")
+              context.fail!(application_error: CommandTower::Errors::InternalError.new)
+            end
+
+            result
+          end
+
+          def deliver(phone, secret)
+            delivery = CommandTower::Identity::PhoneVerification::SmsTransport.deliver(
+              to: phone,
+              body: "Your verification code is #{secret}"
+            )
+            return if delivery.success?
+
+            log_error(
+              {
+                event: "phone_verification_sms_failed",
+                error_code: delivery.error_code,
+                to_masked: mask_phone(phone)
+              }.to_json
+            )
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneVerificationSendFailedError.new)
+          end
+
+          def send_unavailable!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneVerificationSendFailedError.new)
+          end
+
+          def phone_missing!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneMissingError.new)
+          end
+
+          def already_verified!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneAlreadyVerifiedError.new)
+          end
+
+          def mask_phone(value)
+            digits = value.to_s.gsub(/\D/, "")
+            return "[redacted]" if digits.length < 4
+
+            "#{"*" * (digits.length - 4)}#{digits[-4,]}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/phone_verification/verify.rb
+++ b/app/services/command_tower/services/account/phone_verification/verify.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module PhoneVerification
+        # Redeems a phone verification code and marks the phone validated.
+        class Verify < CommandTower::Services::ApplicationService
+          EXPIRED_FRAGMENT = "Expired"
+
+          validate :user, is_a: User, required: true
+          validate :code, is_a: String, required: true, sensitive: true
+
+          def call
+            phone_missing! if user.phone_number.to_s.strip.blank?
+
+            if user.phone_number_validated
+              context.user = user
+              context.already_verified = true
+              return
+            end
+
+            User.transaction do
+              locked = User.lock.find(user.id)
+              phone = locked.phone_number.to_s.strip
+
+              phone_missing! if phone.blank?
+
+              if locked.phone_number_validated
+                context.user = locked
+                context.already_verified = true
+                return
+              end
+
+              redeem!(locked, phone)
+
+              locked.update!(phone_number_validated: true)
+              CommandTower::Secrets::Cleanse.(user: locked, reason: CommandTower::Secrets::PHONE_VERIFICATION)
+              context.user = locked.reload
+              context.already_verified = false
+            end
+          end
+
+          private
+
+          def redeem!(locked, phone)
+            challenge = UserSecret.find_by(
+              secret: code,
+              reason: CommandTower::Secrets::PHONE_VERIFICATION
+            )
+
+            invalid_code! if challenge.nil? || challenge.user_id != locked.id
+            stale_challenge! if challenge.extra.to_s != phone
+
+            result = CommandTower::Secrets::Verify.(
+              secret: code,
+              reason: CommandTower::Secrets::PHONE_VERIFICATION,
+              access_count: true
+            )
+
+            if result.failure?
+              expired_code! if result.msg.to_s.include?(EXPIRED_FRAGMENT)
+              invalid_code!
+            end
+
+            invalid_code! if result.user != locked
+          end
+
+          def phone_missing!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneMissingError.new)
+          end
+
+          def invalid_code!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneVerificationCodeInvalidError.new)
+          end
+
+          def stale_challenge!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneVerificationStaleError.new)
+          end
+
+          def expired_code!
+            context.fail!(application_error: CommandTower::Errors::Account::PhoneVerificationExpiredError.new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/create.rb
+++ b/app/services/command_tower/services/account/pushover/create.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        class Create < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+          validate :user_key, is_a: String, required: true
+          validate :application_token, is_a: String, required: true
+
+          def call
+            context.safe_view = CommandTower::Messaging::Endpoints.create(
+              owner_user_id: user.id,
+              channel_key: "pushover",
+              credentials: {
+                user_key:,
+                application_token:
+              }
+            )
+          rescue CommandTower::Messaging::Endpoints::Error => e
+            context.fail!(application_error: CtSupport.map_ct_exception!(e))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/ct_support.rb
+++ b/app/services/command_tower/services/account/pushover/ct_support.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        # Shared CT Endpoints helpers for Account Pushover capability services.
+        module CtSupport
+          module_function
+
+          def active_endpoint(user)
+            views = CommandTower::Messaging::Endpoints.list(
+              owner_user_id: user.id,
+              channel_key: "pushover"
+            )
+            views.find { |view| view.lifecycle_state.to_s == "active" }
+          end
+
+          def map_ct_exception!(error)
+            case error
+            when CommandTower::Messaging::Endpoints::VerificationFailedError
+              map_verification_failed!(error)
+            when CommandTower::Messaging::Endpoints::ConflictError
+              CommandTower::Errors::Account::PushoverAlreadyConfiguredError.new
+            when CommandTower::Messaging::Endpoints::NotFoundError
+              CommandTower::Errors::Account::PushoverNotConfiguredError.new
+            when CommandTower::Messaging::Endpoints::ValidationError
+              if error.message.to_s.include?("disabled")
+                CommandTower::Errors::Account::PushoverCapabilityUnavailableError.new
+              else
+                CommandTower::Errors::ValidationError.new(details: { base: "Invalid Pushover credentials" })
+              end
+            else
+              CommandTower::Errors::InternalError.new
+            end
+          end
+
+          def map_verification_failed!(error)
+            case error.error_code
+            when :invalid_user
+              CommandTower::Errors::Account::PushoverVerificationFailedError.new(
+                code: "pushover_invalid_user",
+                message: "Pushover user key is invalid"
+              )
+            when :invalid_token
+              CommandTower::Errors::Account::PushoverVerificationFailedError.new(
+                code: "pushover_invalid_token",
+                message: "Pushover application token is invalid"
+              )
+            when :invalid_credentials
+              CommandTower::Errors::Account::PushoverVerificationFailedError.new(
+                code: "pushover_invalid_credentials",
+                message: "Pushover credentials were rejected"
+              )
+            when :timeout
+              CommandTower::Errors::Account::PushoverVerificationFailedError.new(
+                code: "pushover_provider_timeout",
+                message: "Pushover provider timed out"
+              )
+            when :provider_unavailable
+              CommandTower::Errors::Account::PushoverProviderUnavailableError.new
+            else
+              CommandTower::Errors::Account::PushoverVerificationFailedError.new
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/destroy.rb
+++ b/app/services/command_tower/services/account/pushover/destroy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        class Destroy < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+
+          def call
+            active = CtSupport.active_endpoint(user)
+            if active.nil?
+              context.fail!(application_error: CommandTower::Errors::Account::PushoverNotConfiguredError.new)
+              return
+            end
+
+            begin
+              context.safe_view = CommandTower::Messaging::Endpoints.revoke(
+                owner_user_id: user.id,
+                endpoint_id: active.id
+              )
+            rescue CommandTower::Messaging::Endpoints::Error => e
+              context.fail!(application_error: CtSupport.map_ct_exception!(e))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/replace.rb
+++ b/app/services/command_tower/services/account/pushover/replace.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        class Replace < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+          validate :user_key, is_a: String, required: true
+          validate :application_token, is_a: String, required: true
+
+          def call
+            context.safe_view = CommandTower::Messaging::Endpoints.replace(
+              owner_user_id: user.id,
+              channel_key: "pushover",
+              credentials: {
+                user_key:,
+                application_token:
+              }
+            )
+          rescue CommandTower::Messaging::Endpoints::Error => e
+            context.fail!(application_error: CtSupport.map_ct_exception!(e))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/show.rb
+++ b/app/services/command_tower/services/account/pushover/show.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        class Show < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+
+          def call
+            context.safe_view = CtSupport.active_endpoint(user)
+          rescue CommandTower::Messaging::Endpoints::Error => e
+            context.fail!(application_error: CtSupport.map_ct_exception!(e))
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/account/pushover/verify.rb
+++ b/app/services/command_tower/services/account/pushover/verify.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Account
+      module Pushover
+        class Verify < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+
+          def call
+            active = CtSupport.active_endpoint(user)
+            if active.nil?
+              context.fail!(application_error: CommandTower::Errors::Account::PushoverNotConfiguredError.new)
+              return
+            end
+
+            begin
+              context.safe_view = CommandTower::Messaging::Endpoints.verify_pushover!(
+                owner_user_id: user.id,
+                endpoint_id: active.id
+              )
+            rescue CommandTower::Messaging::Endpoints::Error => e
+              context.fail!(application_error: CtSupport.map_ct_exception!(e))
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/me/capabilities.rb
+++ b/app/services/command_tower/services/me/capabilities.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Me
+      # Projects which Account self-service actions are enabled for the current user.
+      class Capabilities
+        def self.project(user)
+          new(user).project
+        end
+
+        def initialize(user)
+          @user = user
+        end
+
+        def project
+          {
+            editName: { enabled: true },
+            editUsername: { enabled: false },
+            changeEmail: { enabled: false },
+            changePassword: { enabled: true },
+            editPhone: { enabled: sms_enabled? },
+            editPushover: { enabled: pushover_enabled? },
+            logoutAllDevices: { enabled: false },
+            verifyEmail: { enabled: !user.email_validated }
+          }
+        end
+
+        private
+
+        attr_reader :user
+
+        def sms_enabled?
+          CommandTower::Messaging::ChannelDetectors.sms_product_ready?
+        end
+
+        def pushover_enabled?
+          CommandTower::Messaging::ChannelDetectors.pushover_configured?
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/me/change_password.rb
+++ b/app/services/command_tower/services/me/change_password.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Me
+      class ChangePassword < CommandTower::Services::ApplicationService
+        FIELD_KEYS = {
+          current_password: :currentPassword,
+          password: :password,
+          password_confirmation: :passwordConfirmation
+        }.freeze
+
+        SUCCESS_MESSAGE = "Password has been successfully changed"
+
+        validate :user, is_a: User, required: true
+        validate :current_password, is_a: String, required: true, sensitive: true
+        validate :password, is_a: String, required: true, sensitive: true
+        validate :password_confirmation, is_a: String, required: true, sensitive: true
+
+        def call
+          reject!(current_password: "Incorrect current password") unless user.authenticate(current_password)
+          reject!(password_confirmation: "Password and confirmation do not match") unless password == password_confirmation
+
+          config = CommandTower.config.login.plain_text
+          if password.length < config.password_length_min || password.length > config.password_length_max
+            reject!(
+              password: "Password length must be between #{config.password_length_min} and #{config.password_length_max} characters"
+            )
+          end
+
+          persistence_errors = nil
+          infrastructure_failure = false
+
+          ActiveRecord::Base.transaction do
+            user.password = password
+            user.password_confirmation = password_confirmation
+
+            unless user.save
+              persistence_errors = user.errors.to_hash.transform_values { Array(_1).join(", ") }
+              raise ActiveRecord::Rollback
+            end
+
+            begin
+              user.reset_verifier_token!
+            rescue StandardError => e
+              log_error("Failed to rotate session verifier for user [#{user.id}]: #{e.class}")
+              infrastructure_failure = true
+              raise ActiveRecord::Rollback
+            end
+          end
+
+          if persistence_errors
+            log_error("Failed to update password for user [#{user.id}]")
+            reject!(persistence_errors)
+          end
+
+          if infrastructure_failure
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          end
+
+          # Detect silent rollback (neither branch set) — should not occur in normal paths
+          user.reload
+          unless user.authenticate(password)
+            log_error("Password change transaction did not persist for user [#{user.id}]")
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          end
+
+          log_info("Password changed successfully for user [#{user.id}]")
+          context.message = SUCCESS_MESSAGE
+        end
+
+        private
+
+        def reject!(errors)
+          details = errors.each_with_object({}) do |(key, message), mapped|
+            mapped[FIELD_KEYS.fetch(key.to_sym, key)] = message
+          end
+
+          context.fail!(application_error: CommandTower::Errors::ValidationError.new(details:))
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/me/pushover_product_gate.rb
+++ b/app/services/command_tower/services/me/pushover_product_gate.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Me
+      # Product gate for Pushover-dependent Me/Account endpoint lifecycle HTTP.
+      # Matches host Capabilities::Pushover.enabled? (pushover_configured?).
+      # Does not invent route constraints — callers return 503 when disabled.
+      module PushoverProductGate
+        module_function
+
+        def enabled?
+          CommandTower::Messaging::ChannelDetectors.pushover_configured?
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/me/sms_product_gate.rb
+++ b/app/services/command_tower/services/me/sms_product_gate.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Me
+      # Product gate for SMS-dependent Me/Account phone lifecycle HTTP.
+      # Matches Me::Capabilities#sms_enabled? / host Capabilities::Sms.enabled?:
+      # Messaging notification SMS configured ∧ Identity OTP SMS ready.
+      # Does not invent route constraints — callers return 503 when disabled.
+      module SmsProductGate
+        module_function
+
+        def enabled?
+          CommandTower::Messaging::ChannelDetectors.sms_product_ready?
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/me/update_name.rb
+++ b/app/services/command_tower/services/me/update_name.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Me
+      class UpdateName < CommandTower::Services::ApplicationService
+        validate :user, is_a: User, required: true
+        validate :first_name, is_a: String, required: true
+        validate :last_name, is_a: String, required: true
+
+        def call
+          normalized_first = first_name.to_s.strip
+          normalized_last = last_name.to_s.strip
+
+          first_changed = normalized_first != user.first_name.to_s
+          last_changed = normalized_last != user.last_name.to_s
+
+          unless first_changed || last_changed
+            context.user = user
+            return
+          end
+
+          application_error = nil
+
+          ActiveRecord::Base.transaction do
+            if first_changed
+              application_error = mutate(first_name: normalized_first)
+              raise ActiveRecord::Rollback if application_error
+            end
+
+            if last_changed
+              application_error = mutate(last_name: normalized_last)
+              raise ActiveRecord::Rollback if application_error
+            end
+          end
+
+          if application_error
+            context.fail!(application_error:)
+            return
+          end
+
+          context.user = user.reload
+        end
+
+        private
+
+        # Returns an ApplicationError when the change was rejected, nil otherwise.
+        def mutate(**attribute)
+          result = CommandTower::UserAttributes::Mutate.call(user:, **attribute)
+          return nil if result.success?
+
+          details = result.invalid_argument_hash.transform_values { _1[:msg].to_s }
+          CommandTower::Errors::ValidationError.new(details:)
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/messaging/inbox.rb
+++ b/app/services/command_tower/services/messaging/inbox.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Messaging
+      module Inbox
+        module FailureMapping
+          private
+
+          def with_recipient
+            result = CommandTower::Services::Messaging::Recipients.call(user:)
+            return context.fail!(application_error: result.errors.first) unless result.success?
+
+            yield result.data[:recipient_id]
+          rescue CommandTower::Messaging::Inbox::InvalidBulkItemsError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message, invalid_ids: error.invalid_ids }))
+          rescue CommandTower::Messaging::Inbox::ValidationError, CommandTower::Messaging::Contract::ValidationError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message }))
+          rescue CommandTower::Messaging::Inbox::NotFoundError
+            context.fail!(application_error: CommandTower::Errors::NotFoundError.new)
+          rescue CommandTower::Messaging::Inbox::InvariantError, CommandTower::Messaging::Contract::NotFoundError,
+                 CommandTower::Messaging::Inbox::Error, CommandTower::Messaging::Contract::Error
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          end
+        end
+
+        class List < CommandTower::Services::ApplicationService
+          include FailureMapping
+          validate :user, is_a: User, required: true
+          validate :limit, is_a: Integer, required: true
+          validate :offset, is_a: Integer, required: true
+          validate :scope, is_a: String, required: false, default: "inbox"
+
+          def call
+            with_recipient do |recipient_id|
+              result = CommandTower::Messaging::Inbox.list(recipient_id:, limit:, offset:, scope:)
+              context.items = result.items.map { |item| Inbox.item(item) }
+              context.pagination = { limit: result.limit, offset: result.offset, total_count: result.total_count }
+            end
+          end
+        end
+
+        class Show < CommandTower::Services::ApplicationService
+          include FailureMapping
+          validate :user, is_a: User, required: true
+          validate :inbox_item_id, is_a: Integer, required: true
+
+          def call
+            with_recipient { |recipient_id| context.item = Inbox.detail(recipient_id:, inbox_item_id:) }
+          end
+        end
+
+        class Open < Show
+          def call
+            with_recipient do |recipient_id|
+              Inbox.detail(recipient_id:, inbox_item_id:)
+              CommandTower::Messaging::Inbox.mark_viewed(recipient_id:, inbox_item_id:)
+              context.item = Inbox.detail(recipient_id:, inbox_item_id:)
+            end
+          end
+        end
+
+        class Archive < CommandTower::Services::ApplicationService
+          include FailureMapping
+          validate :user, is_a: User, required: true
+          validate :inbox_item_id, is_a: Integer, required: true
+
+          def call
+            with_recipient { |recipient_id| context.item = Inbox.item(CommandTower::Messaging::Inbox.archive(recipient_id:, inbox_item_id:)) }
+          end
+        end
+
+        class Delete < CommandTower::Services::ApplicationService
+          include FailureMapping
+          validate :user, is_a: User, required: true
+          validate :inbox_item_id, is_a: Integer, required: true
+
+          def call
+            with_recipient { |recipient_id| CommandTower::Messaging::Inbox.delete(recipient_id:, inbox_item_id:) }
+          end
+        end
+
+        class UnreadCount < CommandTower::Services::ApplicationService
+          include FailureMapping
+          validate :user, is_a: User, required: true
+
+          def call
+            with_recipient { |recipient_id| context.count = CommandTower::Messaging::Inbox.unread_count(recipient_id:).count }
+          end
+        end
+
+        module BulkMutation
+          def call
+            with_recipient do |recipient_id|
+              result = yield(recipient_id)
+              context.bulk_result = { ids: result.ids, count: result.count, changed_count: result.changed_count }
+            end
+          end
+        end
+
+        %i[Read Unread Archive Restore Delete].each do |action|
+          operation = "bulk_#{action.to_s.downcase == "read" ? "mark_viewed" : action.to_s.downcase == "unread" ? "mark_unviewed" : action.to_s.downcase}"
+          const_set(:"Bulk#{action}", Class.new(CommandTower::Services::ApplicationService) do
+            include FailureMapping
+            include BulkMutation
+            validate :user, is_a: User, required: true
+            validate :inbox_item_ids, is_a: Array, required: true
+
+            define_method(:call) { super() { |recipient_id| CommandTower::Messaging::Inbox.public_send(operation, recipient_id:, inbox_item_ids:) } }
+          end)
+        end
+
+        class << self
+          def item(item)
+            { id: item.id, title: item.title, status: item.status, viewed_at: item.viewed_at, created_at: item.created_at, updated_at: item.updated_at }
+          end
+
+          def detail(recipient_id:, inbox_item_id:)
+            item = CommandTower::Messaging::Inbox.show(recipient_id:, inbox_item_id:)
+            communication = CommandTower::Messaging::Contract::Communications.find(
+              CommandTower::Messaging::Contract::Requests::FindCommunication.build(communication_id: item.communication_id, recipient_id:)
+            )
+            item(item).merge(body: communication.body, metadata: communication.metadata, notification_type_key: communication.notification_type_key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/messaging/preferences/platform_enabled_channels.rb
+++ b/app/services/command_tower/services/messaging/preferences/platform_enabled_channels.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Messaging
+      module Preferences
+        # Resolves host-injected platform channel enablement without reverse
+        # dependencies. Hosts assign config.messaging.platform_enabled_channels.
+        module PlatformEnabledChannels
+          module_function
+
+          def call
+            resolver = CommandTower.config.messaging.platform_enabled_channels
+            Array(resolver.call).map(&:to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/messaging/preferences/show.rb
+++ b/app/services/command_tower/services/messaging/preferences/show.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Messaging
+      module Preferences
+        class Show < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+
+          def call
+            recipient_result = CommandTower::Services::Messaging::Recipients.call(user: user)
+            unless recipient_result.success?
+              context.fail!(application_error: recipient_result.errors.first)
+              return
+            end
+
+            catalog = CommandTower::Messaging::Preferences.catalog(
+              recipient_id: recipient_result.data[:recipient_id],
+              platform_enabled_channels: PlatformEnabledChannels.call,
+            )
+
+            context.catalog = catalog
+          rescue CommandTower::Messaging::Preferences::UnknownTypeError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message }))
+          rescue CommandTower::Messaging::Preferences::InvalidPreferenceStateError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message }))
+          rescue CommandTower::Messaging::Preferences::StoreError
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          rescue CommandTower::Messaging::Preferences::Error
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/services/command_tower/services/messaging/preferences/update.rb
+++ b/app/services/command_tower/services/messaging/preferences/update.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Services
+    module Messaging
+      module Preferences
+        class Update < CommandTower::Services::ApplicationService
+          validate :user, is_a: User, required: true
+          validate :notification_type_key, is_a: String, required: true
+          validate :preference_state, is_a: Hash, required: true
+
+          def call
+            recipient_result = CommandTower::Services::Messaging::Recipients.call(user: user)
+            unless recipient_result.success?
+              context.fail!(application_error: recipient_result.errors.first)
+              return
+            end
+
+            notification = CommandTower::Messaging::Preferences.update(
+              recipient_id: recipient_result.data[:recipient_id],
+              notification_type_key:,
+              preference_state:,
+              platform_enabled_channels: PlatformEnabledChannels.call,
+            )
+
+            context.notification = notification
+          rescue CommandTower::Messaging::Preferences::UnknownTypeError,
+                 CommandTower::Messaging::Preferences::NotSettingsVisibleError
+            context.fail!(application_error: CommandTower::Errors::NotFoundError.new)
+          rescue CommandTower::Messaging::Preferences::InvalidPreferenceWriteError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message }))
+          rescue CommandTower::Messaging::Preferences::InvalidPreferenceStateError => error
+            context.fail!(application_error: CommandTower::Errors::ValidationError.new(details: { messaging: error.message }))
+          rescue CommandTower::Messaging::Preferences::StoreError
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          rescue CommandTower::Messaging::Preferences::Error
+            context.fail!(application_error: CommandTower::Errors::InternalError.new)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/command_tower/messaging/rendering/pushover.text.erb
+++ b/app/views/command_tower/messaging/rendering/pushover.text.erb
@@ -1,0 +1,1 @@
+<%= body %><% if deep_link %> <%= deep_link %><% end %>

--- a/app/workflows/command_tower/workflows/me/change_password_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/change_password_workflow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      class ChangePasswordWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, current_password:, password:, password_confirmation:)
+          change_result = CommandTower::Services::Me::ChangePassword.call(
+            user: current_user,
+            current_password:,
+            password:,
+            password_confirmation:
+          )
+
+          unless change_result.success?
+            error = change_result.errors.first
+            return failure(
+              errors: change_result.errors,
+              http_status: CommandTower::Workflows::Me::ErrorStatus.http_status_for(error)
+            )
+          end
+
+          success(
+            payload: CommandTower::Serializers::Me::ChangePasswordResponseSerializer.serialize,
+            http_status: :ok,
+            response_effects: { clear_token: true }
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/clear_phone_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/clear_phone_workflow.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      class ClearPhoneWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, auth_context: nil)
+          unless CommandTower::Services::Me::SmsProductGate.enabled?
+            error = CommandTower::Errors::Account::SmsCapabilityUnavailableError.new
+            return failure(
+              errors: [error],
+              http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+            )
+          end
+
+          clear_result = CommandTower::Services::Account::ClearPhone.call(user: current_user)
+
+          unless clear_result.success?
+            error = clear_result.errors.first
+            return failure(
+              errors: clear_result.errors,
+              http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+            )
+          end
+
+          user = clear_result.data[:user].reload
+          capabilities = CommandTower::Services::Me::Capabilities.project(user)
+          payload = CommandTower::Serializers::Me::AccountSerializer.serialize(
+            user,
+            capabilities: capabilities
+          )
+
+          success(
+            payload: payload,
+            http_status: :ok,
+            response_effects: expire_header_effects(auth_context)
+          )
+        end
+
+        private
+
+        def expire_header_effects(auth_context)
+          return if auth_context.nil?
+
+          { set_expire_header: auth_context.token_expires_at }
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/error_mapping.rb
+++ b/app/workflows/command_tower/workflows/me/error_mapping.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      # HTTP status mapping for Me/Account workflow failures.
+      # Includes phone (2.8) and pushover (host until 2.9) account errors.
+      module ErrorMapping
+        module_function
+
+        def http_status_for(error)
+          case error
+          when CommandTower::Errors::ForbiddenError
+            :forbidden
+          when CommandTower::Errors::Auth::EmailVerificationRequiredError
+            :precondition_failed
+          when CommandTower::Errors::UnauthorizedError
+            :unauthorized
+          when CommandTower::Errors::Account::PhoneVerificationCodeInvalidError,
+               CommandTower::Errors::Account::PhoneVerificationExpiredError,
+               CommandTower::Errors::Account::PhoneVerificationStaleError,
+               CommandTower::Errors::Account::PhoneMissingError,
+               CommandTower::Errors::Account::PhoneAlreadyVerifiedError,
+               CommandTower::Errors::Account::PushoverNotConfiguredError,
+               CommandTower::Errors::Account::PushoverAlreadyConfiguredError,
+               CommandTower::Errors::Account::PushoverVerificationFailedError,
+               CommandTower::Errors::ValidationError
+            :unprocessable_entity
+          when CommandTower::Errors::Account::PhoneVerificationThrottledError
+            :too_many_requests
+          when CommandTower::Errors::Account::SmsCapabilityUnavailableError,
+               CommandTower::Errors::Account::PushoverCapabilityUnavailableError
+            :service_unavailable
+          when CommandTower::Errors::Account::PhoneVerificationSendFailedError,
+               CommandTower::Errors::Account::PushoverProviderUnavailableError
+            :bad_gateway
+          when CommandTower::Errors::InternalError
+            :internal_server_error
+          else
+            :internal_server_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/error_status.rb
+++ b/app/workflows/command_tower/workflows/me/error_status.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module ErrorStatus
+        module_function
+
+        def http_status_for(error)
+          case error
+          when CommandTower::Errors::ForbiddenError
+            :forbidden
+          when CommandTower::Errors::Auth::EmailVerificationRequiredError
+            :precondition_failed
+          when CommandTower::Errors::UnauthorizedError
+            :unauthorized
+          when CommandTower::Errors::ValidationError
+            :unprocessable_entity
+          when CommandTower::Errors::InternalError
+            :internal_server_error
+          else
+            :internal_server_error
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/phone_verification/send_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/phone_verification/send_workflow.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module PhoneVerification
+        class SendWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, auth_context: nil)
+            unless CommandTower::Services::Me::SmsProductGate.enabled?
+              error = CommandTower::Errors::Account::SmsCapabilityUnavailableError.new
+              return failure(
+                errors: [error],
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            send_result = CommandTower::Services::Account::PhoneVerification::Send.call(user: current_user)
+
+            unless send_result.success?
+              error = send_result.errors.first
+              return failure(
+                errors: send_result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error),
+                meta: throttle_meta(error) || {}
+              )
+            end
+
+            data = send_result.data
+            success(
+              payload: {
+                codeLength: data[:code_length],
+                expiresAt: iso(data[:expires_at]),
+                resendAvailableAt: iso(data[:resend_available_at]),
+                phoneNumber: data[:phone_number]
+              }.compact,
+              http_status: :ok,
+              response_effects: expire_header_effects(auth_context)
+            )
+          end
+
+          private
+
+          def iso(value)
+            value.respond_to?(:iso8601) ? value.iso8601 : value
+          end
+
+          def throttle_meta(error)
+            return unless error.is_a?(CommandTower::Errors::Account::PhoneVerificationThrottledError)
+            return if error.resend_available_at.blank?
+
+            { resendAvailableAt: iso(error.resend_available_at) }
+          end
+
+          def expire_header_effects(auth_context)
+            return if auth_context.nil?
+
+            { set_expire_header: auth_context.token_expires_at }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/phone_verification/verify_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/phone_verification/verify_workflow.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module PhoneVerification
+        class VerifyWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, code:, auth_context: nil)
+            unless CommandTower::Services::Me::SmsProductGate.enabled?
+              error = CommandTower::Errors::Account::SmsCapabilityUnavailableError.new
+              return failure(
+                errors: [error],
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            verify_result = CommandTower::Services::Account::PhoneVerification::Verify.call(
+              user: current_user,
+              code:
+            )
+
+            unless verify_result.success?
+              error = verify_result.errors.first
+              return failure(
+                errors: verify_result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            user = verify_result.data[:user].reload
+            capabilities = CommandTower::Services::Me::Capabilities.project(user)
+            payload = CommandTower::Serializers::Me::AccountSerializer.serialize(
+              user,
+              capabilities: capabilities
+            )
+
+            success(
+              payload: payload,
+              http_status: :ok,
+              response_effects: expire_header_effects(auth_context)
+            )
+          end
+
+          private
+
+          def expire_header_effects(auth_context)
+            return if auth_context.nil?
+
+            { set_expire_header: auth_context.token_expires_at }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/create_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/create_workflow.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        class CreateWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, user_key:, application_token:, auth_context: nil)
+            unless CommandTower::Services::Me::PushoverProductGate.enabled?
+              return failure(**WorkflowSupport.capability_failure)
+            end
+
+            result = CommandTower::Services::Account::Pushover::Create.call(
+              user: current_user,
+              user_key:,
+              application_token:
+            )
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            success(
+              payload: WorkflowSupport.serialize_view(result.data[:safe_view]),
+              http_status: :ok,
+              response_effects: WorkflowSupport.expire_header_effects(auth_context)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/destroy_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/destroy_workflow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        class DestroyWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, auth_context: nil)
+            unless CommandTower::Services::Me::PushoverProductGate.enabled?
+              return failure(**WorkflowSupport.capability_failure)
+            end
+
+            result = CommandTower::Services::Account::Pushover::Destroy.call(user: current_user)
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            success(
+              payload: CommandTower::Serializers::Me::PushoverSerializer.unconfigured,
+              http_status: :ok,
+              response_effects: WorkflowSupport.expire_header_effects(auth_context)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/replace_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/replace_workflow.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        class ReplaceWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, user_key:, application_token:, auth_context: nil)
+            unless CommandTower::Services::Me::PushoverProductGate.enabled?
+              return failure(**WorkflowSupport.capability_failure)
+            end
+
+            result = CommandTower::Services::Account::Pushover::Replace.call(
+              user: current_user,
+              user_key:,
+              application_token:
+            )
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            success(
+              payload: WorkflowSupport.serialize_view(result.data[:safe_view]),
+              http_status: :ok,
+              response_effects: WorkflowSupport.expire_header_effects(auth_context)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/show_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/show_workflow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        class ShowWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, auth_context: nil)
+            unless CommandTower::Services::Me::PushoverProductGate.enabled?
+              return failure(**WorkflowSupport.capability_failure)
+            end
+
+            result = CommandTower::Services::Account::Pushover::Show.call(user: current_user)
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            success(
+              payload: WorkflowSupport.serialize_view(result.data[:safe_view]),
+              http_status: :ok,
+              response_effects: WorkflowSupport.expire_header_effects(auth_context)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/verify_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/verify_workflow.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        class VerifyWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(current_user:, auth_context: nil)
+            unless CommandTower::Services::Me::PushoverProductGate.enabled?
+              return failure(**WorkflowSupport.capability_failure)
+            end
+
+            result = CommandTower::Services::Account::Pushover::Verify.call(user: current_user)
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            success(
+              payload: WorkflowSupport.serialize_view(result.data[:safe_view]),
+              http_status: :ok,
+              response_effects: WorkflowSupport.expire_header_effects(auth_context)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/pushover/workflow_support.rb
+++ b/app/workflows/command_tower/workflows/me/pushover/workflow_support.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      module Pushover
+        module WorkflowSupport
+          module_function
+
+          def capability_failure
+            error = CommandTower::Errors::Account::PushoverCapabilityUnavailableError.new
+            {
+              errors: [error],
+              http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+            }
+          end
+
+          def expire_header_effects(auth_context)
+            return if auth_context.nil?
+
+            { set_expire_header: auth_context.token_expires_at }
+          end
+
+          def serialize_view(safe_view)
+            CommandTower::Serializers::Me::PushoverSerializer.serialize(safe_view)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/show_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/show_workflow.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      class ShowWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, auth_context: nil)
+          capabilities = CommandTower::Services::Me::Capabilities.project(current_user)
+          payload = CommandTower::Serializers::Me::AccountSerializer.serialize(
+            current_user,
+            capabilities: capabilities
+          )
+
+          success(
+            payload: payload,
+            http_status: :ok,
+            response_effects: expire_header_effects(auth_context)
+          )
+        end
+
+        private
+
+        def expire_header_effects(auth_context)
+          return if auth_context.nil?
+
+          { set_expire_header: auth_context.token_expires_at }
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/update_name_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/update_name_workflow.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      class UpdateNameWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, first_name:, last_name:, auth_context: nil)
+          update_result = CommandTower::Services::Me::UpdateName.call(
+            user: current_user,
+            first_name:,
+            last_name:
+          )
+
+          unless update_result.success?
+            error = update_result.errors.first
+            return failure(
+              errors: update_result.errors,
+              http_status: CommandTower::Workflows::Me::ErrorStatus.http_status_for(error)
+            )
+          end
+
+          user = update_result.data[:user].reload
+          capabilities = CommandTower::Services::Me::Capabilities.project(user)
+          payload = CommandTower::Serializers::Me::AccountSerializer.serialize(
+            user,
+            capabilities: capabilities
+          )
+
+          success(
+            payload: payload,
+            http_status: :ok,
+            response_effects: expire_header_effects(auth_context)
+          )
+        end
+
+        private
+
+        def expire_header_effects(auth_context)
+          return if auth_context.nil?
+
+          { set_expire_header: auth_context.token_expires_at }
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/me/update_phone_workflow.rb
+++ b/app/workflows/command_tower/workflows/me/update_phone_workflow.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Me
+      class UpdatePhoneWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, phone_number:, auth_context: nil)
+          unless CommandTower::Services::Me::SmsProductGate.enabled?
+            error = CommandTower::Errors::Account::SmsCapabilityUnavailableError.new
+            return failure(
+              errors: [error],
+              http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+            )
+          end
+
+          update_result = CommandTower::Services::Account::UpdatePhone.call(
+            user: current_user,
+            phone_number:
+          )
+
+          unless update_result.success?
+            error = update_result.errors.first
+            return failure(
+              errors: update_result.errors,
+              http_status: CommandTower::Workflows::Me::ErrorMapping.http_status_for(error)
+            )
+          end
+
+          user = update_result.data[:user].reload
+          capabilities = CommandTower::Services::Me::Capabilities.project(user)
+          payload = CommandTower::Serializers::Me::AccountSerializer.serialize(
+            user,
+            capabilities: capabilities
+          )
+
+          success(
+            payload: payload,
+            http_status: :ok,
+            response_effects: expire_header_effects(auth_context)
+          )
+        end
+
+        private
+
+        def expire_header_effects(auth_context)
+          return if auth_context.nil?
+
+          { set_expire_header: auth_context.token_expires_at }
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/messaging/inbox.rb
+++ b/app/workflows/command_tower/workflows/messaging/inbox.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Messaging
+      module Inbox
+        class BaseWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def self.inherited(subclass)
+            super
+            subclass.retry_strategy :none
+          end
+
+          private
+
+          def result_or_failure(result)
+            return result if result.success?
+
+            failure(errors: result.errors, http_status: CommandTower::Workflows::Messaging::ErrorMapping.http_status_for(result.errors.first))
+          end
+        end
+
+        class ListWorkflow < BaseWorkflow
+          def call(user:, limit:, offset:, scope:)
+            result = CommandTower::Services::Messaging::Inbox::List.call(user:, limit:, offset:, scope:)
+            return result_or_failure(result) unless result.success?
+
+            payload = result.data[:items].map { |item| CommandTower::Serializers::Messaging::Inbox::ItemSerializer.serialize(item) }
+            meta = CommandTower::Serializers::Messaging::Inbox::PaginationMetaSerializer.serialize(result.data[:pagination])
+            success(payload:, meta:, http_status: :ok)
+          end
+        end
+
+        class ShowWorkflow < BaseWorkflow
+          def call(user:, inbox_item_id:)
+            result = CommandTower::Services::Messaging::Inbox::Show.call(user:, inbox_item_id:)
+            return result_or_failure(result) unless result.success?
+
+            success(payload: CommandTower::Serializers::Messaging::Inbox::DetailSerializer.serialize(result.data[:item]), http_status: :ok)
+          end
+        end
+
+        class OpenWorkflow < ShowWorkflow
+          def call(user:, inbox_item_id:)
+            result = CommandTower::Services::Messaging::Inbox::Open.call(user:, inbox_item_id:)
+            return result_or_failure(result) unless result.success?
+
+            success(payload: CommandTower::Serializers::Messaging::Inbox::DetailSerializer.serialize(result.data[:item]), http_status: :ok)
+          end
+        end
+
+        class ArchiveWorkflow < BaseWorkflow
+          def call(user:, inbox_item_id:)
+            result = CommandTower::Services::Messaging::Inbox::Archive.call(user:, inbox_item_id:)
+            return result_or_failure(result) unless result.success?
+
+            success(payload: CommandTower::Serializers::Messaging::Inbox::ItemSerializer.serialize(result.data[:item]), http_status: :ok)
+          end
+        end
+
+        class DeleteWorkflow < BaseWorkflow
+          def call(user:, inbox_item_id:)
+            result = CommandTower::Services::Messaging::Inbox::Delete.call(user:, inbox_item_id:)
+            return result_or_failure(result) unless result.success?
+
+            success(payload: nil, http_status: :ok)
+          end
+        end
+
+        class UnreadCountWorkflow < BaseWorkflow
+          def call(user:)
+            result = CommandTower::Services::Messaging::Inbox::UnreadCount.call(user:)
+            return result_or_failure(result) unless result.success?
+
+            success(payload: CommandTower::Serializers::Messaging::Inbox::UnreadCountSerializer.serialize(result.data), http_status: :ok)
+          end
+        end
+
+        { BulkReadWorkflow: :BulkRead, BulkUnreadWorkflow: :BulkUnread, BulkArchiveWorkflow: :BulkArchive,
+          BulkRestoreWorkflow: :BulkRestore, BulkDeleteWorkflow: :BulkDelete }.each do |workflow_name, service_name|
+          const_set(workflow_name, Class.new(BaseWorkflow) do
+            define_method(:call) do |user:, inbox_item_ids:|
+              result = CommandTower::Services::Messaging::Inbox.const_get(service_name).call(user:, inbox_item_ids:)
+              return result_or_failure(result) unless result.success?
+
+              success(
+                payload: CommandTower::Serializers::Messaging::Inbox::BulkResultSerializer.serialize(result.data[:bulk_result]),
+                http_status: :ok
+              )
+            end
+          end)
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/messaging/preferences/show_workflow.rb
+++ b/app/workflows/command_tower/workflows/messaging/preferences/show_workflow.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Messaging
+      module Preferences
+        class ShowWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(user:)
+            result = CommandTower::Services::Messaging::Preferences::Show.call(user:)
+
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Messaging::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            payload = CommandTower::Serializers::Messaging::Preferences::CatalogSerializer.serialize(
+              result.data[:catalog],
+            )
+
+            success(payload:, http_status: :ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/messaging/preferences/update_workflow.rb
+++ b/app/workflows/command_tower/workflows/messaging/preferences/update_workflow.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Messaging
+      module Preferences
+        class UpdateWorkflow < CommandTower::Workflows::ApplicationWorkflow
+          retry_strategy :none
+
+          def call(user:, notification_type_key:, preference_state:)
+            result = CommandTower::Services::Messaging::Preferences::Update.call(
+              user:,
+              notification_type_key:,
+              preference_state:,
+            )
+
+            unless result.success?
+              error = result.errors.first
+              return failure(
+                errors: result.errors,
+                http_status: CommandTower::Workflows::Messaging::ErrorMapping.http_status_for(error)
+              )
+            end
+
+            payload = {
+              notification: CommandTower::Serializers::Messaging::Preferences::NotificationSerializer.serialize(
+                result.data[:notification],
+              ),
+            }
+
+            success(payload:, http_status: :ok)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/workflows/command_tower/workflows/profile/show_workflow.rb
+++ b/app/workflows/command_tower/workflows/profile/show_workflow.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module CommandTower
+  module Workflows
+    module Profile
+      class ShowWorkflow < CommandTower::Workflows::ApplicationWorkflow
+        retry_strategy :none
+
+        def call(current_user:, auth_context: nil)
+          success(
+            payload: CommandTower::Serializers::Profile::ProfileSerializer.serialize(current_user),
+            http_status: :ok,
+            response_effects: expire_header_effects(auth_context)
+          )
+        end
+
+        private
+
+        def expire_header_effects(auth_context)
+          return if auth_context.nil?
+
+          { set_expire_header: auth_context.token_expires_at }
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20260805000004_create_messaging_notification_preferences.rb
+++ b/db/migrate/20260805000004_create_messaging_notification_preferences.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateMessagingNotificationPreferences < ActiveRecord::Migration[8.1]
+  def change
+    create_table :messaging_notification_preferences do |t|
+      t.timestamps
+      t.references :user, null: false, foreign_key: true
+      t.string :notification_type_key, null: false
+      t.text :state, null: false
+    end
+
+    add_index :messaging_notification_preferences,
+              %i[user_id notification_type_key],
+              unique: true,
+              name: "index_messaging_notification_preferences_unique"
+  end
+end

--- a/db/migrate/20260805000005_create_messaging_endpoints_and_pushover_credentials.rb
+++ b/db/migrate/20260805000005_create_messaging_endpoints_and_pushover_credentials.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class CreateMessagingEndpointsAndPushoverCredentials < ActiveRecord::Migration[8.1]
+  def change
+    create_table :messaging_endpoints do |t|
+      t.timestamps
+      t.references :user, null: false, foreign_key: true
+      t.string :channel_key, null: false
+      t.string :lifecycle_state, null: false
+      t.string :verification_state, null: false
+      t.string :address_fingerprint, null: false
+      t.string :masked_display_value, null: false
+      t.text :address_ciphertext # nullable for typed credential channels (e.g. Pushover)
+      t.integer :encryption_key_version, null: false, default: 1
+      t.integer :lock_version, null: false, default: 0
+      t.datetime :verified_at
+      t.datetime :revoked_at
+      t.datetime :last_successful_use_at
+      t.string :active_fingerprint
+      t.string :single_active_slot
+    end
+
+    add_index :messaging_endpoints,
+              %i[user_id channel_key active_fingerprint],
+              unique: true,
+              name: "index_messaging_endpoints_active_fingerprint"
+    add_index :messaging_endpoints,
+              %i[single_active_slot],
+              unique: true,
+              name: "index_messaging_endpoints_single_active_slot"
+    add_index :messaging_endpoints,
+              %i[user_id channel_key],
+              name: "index_messaging_endpoints_owner_channel"
+
+    reversible do |dir|
+      dir.up do
+        execute <<~SQL.squish
+          ALTER TABLE messaging_endpoints
+          ADD CONSTRAINT chk_messaging_endpoints_lifecycle
+          CHECK (lifecycle_state IN ('active', 'revoked', 'invalid', 'retired'))
+        SQL
+        execute <<~SQL.squish
+          ALTER TABLE messaging_endpoints
+          ADD CONSTRAINT chk_messaging_endpoints_verification
+          CHECK (verification_state IN ('unverified', 'pending', 'verified', 'failed'))
+        SQL
+      end
+      dir.down do
+        execute "ALTER TABLE messaging_endpoints DROP CHECK chk_messaging_endpoints_lifecycle"
+        execute "ALTER TABLE messaging_endpoints DROP CHECK chk_messaging_endpoints_verification"
+      end
+    end
+
+    create_table :messaging_endpoint_pushover_credentials do |t|
+      t.timestamps
+      t.bigint :messaging_endpoint_id, null: false
+      t.text :user_key_ciphertext, null: false
+      t.text :application_token_ciphertext, null: false
+      t.integer :encryption_key_version, null: false, default: 1
+    end
+
+    add_index :messaging_endpoint_pushover_credentials,
+              :messaging_endpoint_id,
+              unique: true,
+              name: "index_messaging_pushover_credentials_on_endpoint_id"
+
+    add_foreign_key :messaging_endpoint_pushover_credentials,
+                    :messaging_endpoints,
+                    column: :messaging_endpoint_id,
+                    on_delete: :cascade
+  end
+end

--- a/lib/command_tower/configuration/identity/phone_verification.rb
+++ b/lib/command_tower/configuration/identity/phone_verification.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "class_composer"
+
+module CommandTower
+  module Configuration
+    module Identity
+      class PhoneVerification < ::CommandTower::Configuration::Base
+        include ClassComposer::Generator
+
+        # Same validation style as Configuration::Messaging::Sms (ADAPTERS + ClassComposer validator).
+        ADAPTERS = %w[fake log twilio].freeze
+
+        add_composer :enable,
+          desc: "Enable Identity phone verification OTP send/verify",
+          allowed: [FalseClass, TrueClass],
+          default: true
+
+        add_composer :verify_code_length,
+          desc: "Length of the numeric phone verification OTP (Generate + Identity Policy)",
+          allowed: Integer,
+          default: 6,
+          validator: ->(val) { (val <= 10) && (val >= 4) },
+          invalid_message: ->(val) { "Provided #{val}. Value must be between 4 and 10 inclusive." }
+
+        add_composer :verify_code_valid_for,
+          desc: "How long a phone verification OTP remains valid",
+          allowed: ActiveSupport::Duration,
+          default: 10.minutes,
+          validator: ->(val) { val < 60.minutes },
+          invalid_message: ->(val) { "Provided #{val}. Value must be less than #{60.minutes}" }
+
+        add_composer :resend_cooldown,
+          desc: "Minimum time between phone verification OTP sends for the same user",
+          allowed: ActiveSupport::Duration,
+          default: 30.seconds,
+          validator: ->(val) { val >= 0.seconds && val < 60.minutes },
+          invalid_message: ->(val) { "Provided #{val}. Value must be >= 0 and less than #{60.minutes}" }
+
+        add_composer :sms_from,
+          desc: "Sender identity for phone verification SMS (provider-specific)",
+          allowed: [String, NilClass],
+          default: nil
+
+        add_composer :sms_adapter,
+          desc: "SMS transport adapter name: fake | log | twilio",
+          allowed: String,
+          default: "fake",
+          validator: ->(val) { ADAPTERS.include?(val.to_s) },
+          invalid_message: ->(val) { "Provided #{val.inspect}. Allowed: #{ADAPTERS.join(', ')}" }
+      end
+    end
+  end
+end

--- a/lib/command_tower/configuration/messaging/pushover.rb
+++ b/lib/command_tower/configuration/messaging/pushover.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "class_composer"
+
+module CommandTower
+  module Configuration
+    module Messaging
+      class Pushover < ::CommandTower::Configuration::Base
+        include ClassComposer::Generator
+
+        ADAPTERS = %w[disabled fake log http].freeze
+
+        add_composer :adapter,
+          desc: "Pushover verification transport: disabled | fake | log | http. Default disabled (fail closed).",
+          allowed: String,
+          default: "disabled",
+          validator: ->(val) { ADAPTERS.include?(val.to_s) },
+          invalid_message: ->(val) { "Provided #{val.inspect}. Allowed: #{ADAPTERS.join(', ')}" }
+
+        add_composer :api_base_url,
+          desc: "Pushover API base URL (versioned path included).",
+          allowed: String,
+          default: "https://api.pushover.net/1"
+
+        add_composer :timeout_seconds,
+          desc: "HTTP open/read timeout seconds for Pushover provider calls.",
+          allowed: Integer,
+          default: 5
+
+        add_composer :test_title,
+          desc: "Title for Pushover verification/test notification. Neutral default; hosts override product copy.",
+          allowed: String,
+          default: "Pushover verification"
+
+        add_composer :test_message,
+          desc: "Body for Pushover verification/test notification.",
+          allowed: String,
+          default: "Your Pushover credentials were verified successfully."
+      end
+    end
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/me/change_password_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/me/change_password_deserializer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Me::ChangePasswordDeserializer do
+  describe ".call" do
+    subject(:result) { described_class.call(params) }
+
+    context "with camelCase fields" do
+      let(:params) do
+        {
+          currentPassword: "old",
+          password: "newpassword1234",
+          passwordConfirmation: "newpassword1234"
+        }
+      end
+
+      it "succeeds" do
+        expect(result).to be_success
+        expect(result.input.current_password).to eq("old")
+      end
+    end
+
+    context "with missing fields" do
+      let(:params) { { currentPassword: "old" } }
+
+      it "fails" do
+        expect(result).not_to be_success
+      end
+    end
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/me/pushover/credentials_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/me/pushover/credentials_deserializer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Me::Pushover::CredentialsDeserializer do
+  context "with camelCase aliases" do
+    subject(:result) do
+      described_class.call(
+        ActionController::Parameters.new(
+          "userKey" => " user-key ",
+          "applicationToken" => " app-token "
+        )
+      )
+    end
+
+    it { expect(result).to be_success }
+    it { expect(result.input.user_key).to eq("user-key") }
+    it { expect(result.input.application_token).to eq("app-token") }
+  end
+
+  context "when required fields are blank" do
+    subject(:result) { described_class.call(ActionController::Parameters.new("userKey" => "")) }
+
+    it { expect(result).not_to be_success }
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/me/update_name_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/me/update_name_deserializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Me::UpdateNameDeserializer do
+  describe ".call" do
+    subject(:result) { described_class.call(params) }
+
+    context "with camelCase fields" do
+      let(:params) { { firstName: "Ada", lastName: "Lovelace" } }
+
+      it "succeeds" do
+        expect(result).to be_success
+        expect(result.input.first_name).to eq("Ada")
+        expect(result.input.last_name).to eq("Lovelace")
+      end
+    end
+
+    context "with blank fields" do
+      let(:params) { { firstName: "", lastName: "Lovelace" } }
+
+      it "fails" do
+        expect(result).not_to be_success
+      end
+    end
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/me/update_phone_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/me/update_phone_deserializer_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Me::UpdatePhoneDeserializer do
+  context "with phoneNumber" do
+    subject(:result) { described_class.call(phoneNumber: "4155552671") }
+
+    it { expect(result).to be_success }
+    it { expect(result.input.phone_number).to eq("4155552671") }
+  end
+
+  it "rejects blank phone" do
+    expect(described_class.call(phoneNumber: "  ")).to be_failure
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/messaging/inbox_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/messaging/inbox_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Messaging::Inbox::ListDeserializer do
+  context "with an empty query" do
+    subject(:result) { described_class.call({}) }
+
+    it { expect(result).to be_success }
+
+    it "uses defaults" do
+      expect(result.input).to have_attributes(limit: 50, offset: 0, scope: "inbox")
+    end
+  end
+
+  context "with invalid bulk ids" do
+    subject(:result) { CommandTower::Deserializers::Messaging::Inbox::BulkIdsDeserializer.call(ids: []) }
+
+    it { expect(result).not_to be_success }
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/messaging/preferences/show_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/messaging/preferences/show_deserializer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Messaging::Preferences::ShowDeserializer do
+  describe "#call" do
+    context "with empty trusted input" do
+      subject(:result) { described_class.call({}) }
+
+      it { expect(result).to be_success }
+      it { expect(result.input).to be_a(described_class::Input) }
+    end
+
+    context "with unrelated params" do
+      subject(:result) { described_class.call({ limit: 10, unexpected: "value" }) }
+
+      it { expect(result).to be_success }
+    end
+  end
+end

--- a/spec/deserializers/command_tower/deserializers/messaging/preferences/update_deserializer_spec.rb
+++ b/spec/deserializers/command_tower/deserializers/messaging/preferences/update_deserializer_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Deserializers::Messaging::Preferences::UpdateDeserializer do
+  describe "#call" do
+    context "with a valid preference update" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "booking_confirmation",
+          preferences: {
+            "inboxEnabled" => false,
+            "channels" => { "email" => false },
+          },
+        )
+      end
+
+      it "parses a valid preference update" do
+        expect(result).to be_success
+        expect(result.input.notification_type_key).to eq("booking_confirmation")
+        expect(result.input.preference_state).to eq(
+          "inbox" => false,
+          "channels" => { "email" => false },
+        )
+      end
+    end
+
+    context "with an empty preferences object" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "booking_confirmation",
+          preferences: {},
+        )
+      end
+
+      it "treats an empty preferences object as reset" do
+        expect(result).to be_success
+        expect(result.input.preference_state).to eq({})
+      end
+    end
+
+    context "when preferences are missing" do
+      subject(:result) { described_class.call(notification_type_key: "booking_confirmation") }
+
+      it "rejects missing preferences" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with unexpected top-level fields" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "booking_confirmation",
+          preferences: { "inboxEnabled" => true },
+          label: "nope",
+        )
+      end
+
+      it "rejects unexpected top-level fields" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with unexpected preference fields" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "booking_confirmation",
+          preferences: { "mandatory" => true },
+        )
+      end
+
+      it "rejects unexpected preference fields" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with non-boolean channel values" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "booking_confirmation",
+          preferences: { "channels" => { "email" => "false" } },
+        )
+      end
+
+      it "rejects non-boolean channel values" do
+        expect(result).to be_failure
+      end
+    end
+
+    context "with a blank notification type key" do
+      subject(:result) do
+        described_class.call(
+          notification_type_key: "  ",
+          preferences: {},
+        )
+      end
+
+      it "rejects a blank notification type key" do
+        expect(result).to be_failure
+      end
+    end
+  end
+end

--- a/spec/lib/command_tower/configuration/identity/phone_verification_spec.rb
+++ b/spec/lib/command_tower/configuration/identity/phone_verification_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Configuration::Identity::PhoneVerification do
+  around do |example|
+    previous = CommandTower.config.identity.phone_verification.sms_adapter
+    example.run
+  ensure
+    CommandTower.config.identity.phone_verification.sms_adapter = previous
+  end
+
+  it "accepts the same adapter set as the Messaging SMS validation style (without disabled)" do
+    expect(described_class::ADAPTERS).to eq(%w[fake log twilio])
+
+    %w[fake log twilio].each do |name|
+      expect {
+        CommandTower.config.identity.phone_verification.sms_adapter = name
+      }.not_to raise_error
+      expect(CommandTower.config.identity.phone_verification.sms_adapter).to eq(name)
+    end
+  end
+
+  it "rejects unknown sms_adapter values at configure time" do
+    expect {
+      CommandTower.config.identity.phone_verification.sms_adapter = "disabled"
+    }.to raise_error(ClassComposer::ValidatorError, /Allowed: fake, log, twilio/)
+  end
+end

--- a/spec/models/command_tower/messaging/endpoint_pushover_credential_spec.rb
+++ b/spec/models/command_tower/messaging/endpoint_pushover_credential_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::EndpointPushoverCredential do
+  describe "factory" do
+    subject(:credential) { create(:messaging_endpoint_pushover_credential) }
+
+    it "is valid and associated to a pushover endpoint" do
+      expect(credential).to be_persisted
+      expect(credential.endpoint).to be_persisted
+      expect(credential.endpoint.channel_key).to eq("pushover")
+      expect(credential.user_key_ciphertext).to be_present
+      expect(credential.application_token_ciphertext).to be_present
+      expect(credential.encryption_key_version).to be_present
+    end
+
+    it "stores ciphertext rather than plaintext credentials" do
+      expect(credential.user_key_ciphertext).not_to include("pushover-user-key-abcd")
+      expect(credential.application_token_ciphertext).not_to include("pushover-app-token-zzzz")
+      expect(credential.attributes.values.map(&:to_s).join).not_to include("pushover-user-key-abcd")
+    end
+  end
+
+  describe "associations and validations" do
+    subject(:credential) do
+      build(
+        :messaging_endpoint_pushover_credential,
+        endpoint:,
+        user_key_ciphertext:,
+        application_token_ciphertext:,
+        encryption_key_version:,
+      )
+    end
+
+    let(:endpoint) { create(:messaging_endpoint, :pushover) }
+    let(:user_key_ciphertext) do
+      CommandTower::Messaging::Endpoints::SecretBox.encrypt(
+        "pushover-user-key-abcd",
+        purpose: CommandTower::Messaging::Endpoints::SecretBox::PUSHOVER_USER_KEY_PURPOSE,
+      ).fetch(:ciphertext)
+    end
+    let(:application_token_ciphertext) do
+      CommandTower::Messaging::Endpoints::SecretBox.encrypt(
+        "pushover-app-token-zzzz",
+        purpose: CommandTower::Messaging::Endpoints::SecretBox::PUSHOVER_APPLICATION_TOKEN_PURPOSE,
+      ).fetch(:ciphertext)
+    end
+    let(:encryption_key_version) { CommandTower::Messaging::Endpoints::SecretBox.key_version }
+
+    it "belongs to endpoint" do
+      expect(credential.endpoint).to eq(endpoint)
+    end
+
+    context "when user_key_ciphertext is blank" do
+      let(:user_key_ciphertext) { nil }
+
+      it "is invalid" do
+        expect(credential).not_to be_valid
+        expect(credential.errors[:user_key_ciphertext]).to be_present
+      end
+    end
+
+    context "when application_token_ciphertext is blank" do
+      let(:application_token_ciphertext) { nil }
+
+      it "is invalid" do
+        expect(credential).not_to be_valid
+        expect(credential.errors[:application_token_ciphertext]).to be_present
+      end
+    end
+
+    context "when encryption_key_version is blank" do
+      let(:encryption_key_version) { nil }
+
+      it "is invalid" do
+        expect(credential).not_to be_valid
+        expect(credential.errors[:encryption_key_version]).to be_present
+      end
+    end
+  end
+
+  describe "public encryption round-trip via SecretBox" do
+    subject(:decrypted_user_key) do
+      CommandTower::Messaging::Endpoints::SecretBox.decrypt(
+        credential.user_key_ciphertext,
+        purpose: CommandTower::Messaging::Endpoints::SecretBox::PUSHOVER_USER_KEY_PURPOSE,
+      )
+    end
+
+    let(:credential) { create(:messaging_endpoint_pushover_credential) }
+
+    it "decrypts the factory ciphertext with the public SecretBox API" do
+      expect(decrypted_user_key).to eq("pushover-user-key-abcd")
+    end
+  end
+end

--- a/spec/requests/command_tower/me/inbox_bulk_spec.rb
+++ b/spec/requests/command_tower/me/inbox_bulk_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me inbox bulk mutations", :with_rbac_setup, :messaging_inbox, type: :request do
+  let(:user) { create(:user, roles: ["member"]) }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+  let!(:first) { create_inbox_for(user:) }
+  let!(:second) { create_inbox_for(user:) }
+
+  it "marks requested inbox items read" do
+    post "/me/inbox/bulk/read", params: { ids: [first.id, second.id] }, headers: headers, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["data"]).to include("ids" => contain_exactly(first.id, second.id), "changedCount" => 2)
+    expect([first, second].map(&:reload).map(&:viewed_at)).to all(be_present)
+  end
+end

--- a/spec/requests/command_tower/me/inbox_spec.rb
+++ b/spec/requests/command_tower/me/inbox_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me inbox", :with_rbac_setup, :messaging_inbox, type: :request do
+  let(:user) { create(:user, roles: ["member"]) }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+  let!(:inbox_item) { create_inbox_for(user:) }
+
+  it "rejects unauthenticated requests" do
+    get "/me/inbox"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "lists inbox items for a member" do
+    get "/me/inbox", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["data"].map { |item| item["id"] }).to include(inbox_item.id)
+  end
+
+  context "when the caller lacks roles" do
+    let(:unprivileged_user) { create(:user, roles: []) }
+    let(:unprivileged_headers) { authenticate_request_with_bearer!(unprivileged_user) }
+
+    before { get "/me/inbox", headers: unprivileged_headers }
+
+    it { expect(response).to have_http_status(:forbidden) }
+  end
+
+  it "returns unread count" do
+    get "/me/inbox/unread-count", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig("data", "count")).to eq(1)
+  end
+
+  it "shows, opens, archives, and deletes an owned item" do
+    get "/me/inbox/#{inbox_item.id}", headers: headers
+    expect(response).to have_http_status(:ok)
+
+    post "/me/inbox/#{inbox_item.id}/open", headers: headers
+    expect(response).to have_http_status(:ok)
+    expect(inbox_item.reload.viewed_at).to be_present
+
+    patch "/me/inbox/#{inbox_item.id}/archive", headers: headers
+    expect(response).to have_http_status(:ok)
+
+    delete "/me/inbox/#{inbox_item.id}", headers: headers
+    expect(response).to have_http_status(:ok)
+    expect(inbox_item.reload.deleted_at).to be_present
+  end
+end

--- a/spec/requests/command_tower/me/name_spec.rb
+++ b/spec/requests/command_tower/me/name_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe "PATCH /me/name", :with_rbac_setup, type: :request do
+  subject(:make_request) { patch path, params: params, headers: headers, as: :json }
+
+  let(:path) { "/me/name" }
+  let(:headers) { {} }
+  let(:params) { { firstName: "Grace", lastName: "Hopper" } }
+
+  context "without authentication" do
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unauthorized) }
+  end
+
+  context "with a valid update" do
+    let(:user) { create(:user, roles: ["member"], first_name: "Old", last_name: "Name") }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "returns the updated account" do
+      expect(response.parsed_body["data"]).to include("firstName" => "Grace", "lastName" => "Hopper", "fullName" => "Grace Hopper")
+    end
+
+    it "persists the change" do
+      expect(user.reload).to have_attributes(first_name: "Grace", last_name: "Hopper")
+    end
+  end
+
+  context "with missing fields" do
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+    let(:params) { { firstName: "" } }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unprocessable_entity) }
+  end
+end

--- a/spec/requests/command_tower/me/password_spec.rb
+++ b/spec/requests/command_tower/me/password_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe "PATCH /me/password", :with_rbac_setup, type: :request do
+  subject(:make_request) { patch path, params: params, headers: headers, as: :json }
+
+  let(:path) { "/me/password" }
+  let(:headers) { {} }
+  let(:stored_password) { "password1234abcdef" }
+  let(:new_password) { "newpassword5678ghij" }
+  let(:params) do
+    {
+      currentPassword: stored_password,
+      password: new_password,
+      passwordConfirmation: new_password
+    }
+  end
+
+  context "without authentication" do
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unauthorized) }
+  end
+
+  context "with a valid password change" do
+    let(:user) { create(:user, roles: ["member"], password: stored_password, password_confirmation: stored_password) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "returns a success message only" do
+      expect(response.parsed_body["data"]).to eq("message" => "Password updated successfully.")
+    end
+
+    it "rotates the verifier so the prior token fails" do
+      get "/auth/session", headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+  end
+
+  context "with an incorrect current password" do
+    let(:user) { create(:user, roles: ["member"], password: stored_password, password_confirmation: stored_password) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+    let(:params) do
+      {
+        currentPassword: "wrong-password-here",
+        password: new_password,
+        passwordConfirmation: new_password
+      }
+    end
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unprocessable_entity) }
+  end
+
+  context "with missing fields" do
+    let(:user) { create(:user, roles: ["member"], password: stored_password, password_confirmation: stored_password) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+    let(:params) { { currentPassword: stored_password } }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unprocessable_entity) }
+  end
+end

--- a/spec/requests/command_tower/me/phone_spec.rb
+++ b/spec/requests/command_tower/me/phone_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me phone", :with_rbac_setup, type: :request do
+  let(:user) { create(:user, roles: ["member"]) }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+
+  before do
+    allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+  end
+
+  it "rejects unauthenticated update" do
+    patch "/me/phone", params: { phoneNumber: "4155552671" }, as: :json
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "updates and normalizes a phone number" do
+    patch "/me/phone", headers: headers, params: { phoneNumber: "4155552671" }, as: :json
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body.dig("data", "phoneNumber")).to eq("+14155552671")
+    expect(response.parsed_body.dig("data", "phoneNumberValidated")).to eq(false)
+  end
+
+  context "when clearing phone on delete" do
+    before do
+      user.update!(phone_number: "+14155552671", phone_number_validated: true)
+      delete "/me/phone", headers: headers
+    end
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "clears the phone number" do
+      expect(response.parsed_body.dig("data", "phoneNumber")).to be_nil
+      expect(user.reload.phone_number).to be_nil
+    end
+  end
+
+  context "when SMS product gate is off" do
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+    end
+
+    it "returns service unavailable when SMS product gate is off" do
+      patch "/me/phone", headers: headers, params: { phoneNumber: "4155552671" }, as: :json
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("sms_capability_unavailable")
+    end
+
+    it "does not apply Engine SMS route constraints" do
+      expect(CommandTower::Engine.routes.recognize_path("/me/phone", method: :patch)).to include(
+        controller: "command_tower/me/phone",
+        action: "update",
+      )
+    end
+  end
+end

--- a/spec/requests/command_tower/me/phone_verification_spec.rb
+++ b/spec/requests/command_tower/me/phone_verification_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me phone verification", :with_rbac_setup, type: :request do
+  let(:user) { create(:user, roles: ["member"], phone_number: "+14155552671", phone_number_validated: false) }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+
+  before do
+    allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+    CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+    CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter.reset!
+    allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+    allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(0.seconds)
+  end
+
+  context "when sending a verification code" do
+    subject(:data) { response.parsed_body["data"] }
+
+    before { post "/me/phone/verification", headers: headers }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "returns metadata without leaking the OTP" do
+      expect(data.keys).to include("codeLength", "expiresAt", "resendAvailableAt", "phoneNumber")
+      expect(data.values.join).not_to match(/\b\d{6}\b/)
+      expect(CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter.deliveries).not_to be_empty
+    end
+  end
+
+  context "when verifying a valid code" do
+    let(:code) do
+      post "/me/phone/verification", headers: headers
+      CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter.deliveries.last[:body][/\d{6}/]
+    end
+
+    before { post "/me/phone/verification/verify", headers: headers, params: { code: }, as: :json }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "marks the phone validated" do
+      expect(response.parsed_body.dig("data", "phoneNumberValidated")).to eq(true)
+      expect(user.reload.phone_number_validated).to eq(true)
+    end
+  end
+
+  context "when verifying a blank code" do
+    before { post "/me/phone/verification/verify", headers: headers, params: { code: "" }, as: :json }
+
+    it { expect(response).to have_http_status(:unprocessable_entity) }
+
+    it "returns phone_verification_code_invalid" do
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("phone_verification_code_invalid")
+    end
+  end
+
+  context "when SMS product gate is off" do
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+      post "/me/phone/verification", headers: headers
+    end
+
+    it { expect(response).to have_http_status(:service_unavailable) }
+  end
+end

--- a/spec/requests/command_tower/me/preferences_spec.rb
+++ b/spec/requests/command_tower/me/preferences_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me preferences", :with_rbac_setup, :messaging_preferences, type: :request do
+  let(:user) { create(:user, roles: ["member"], email: "prefs-ct@example.com") }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+
+  before do
+    CommandTower.config.messaging.platform_enabled_channels = -> { %w[email] }
+
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: "booking_confirmation",
+        label: "Booking Confirmation",
+        category_key: "reservations",
+        category_label: "Reservations",
+        category_order: 10,
+        type_order: 10,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => false },
+          "inbox" => true,
+        },
+        settings_visible: true,
+        user_configurable: true,
+      ),
+      build_notification_type_declaration(
+        key: "password_changed",
+        label: "Password Changed",
+        category_key: "account",
+        category_label: "Account",
+        category_order: 30,
+        type_order: 10,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        default_preference_state: {
+          "channels" => { "email" => true },
+          "inbox" => true,
+        },
+        settings_visible: true,
+        user_configurable: false,
+        mandatory: true,
+      ),
+      build_notification_type_declaration(
+        key: "hello_world",
+        label: "Hello World",
+        category_key: "development",
+        category_label: "Development",
+        category_order: 1000,
+        type_order: 10,
+        allowed_channels: [],
+        default_channels: [],
+        default_preference_state: { "channels" => {}, "inbox" => true },
+        settings_visible: false,
+        user_configurable: false,
+      ),
+    )
+  end
+
+  after do
+    CommandTower.config.messaging.platform_enabled_channels = -> { [] }
+  end
+
+  describe "GET /me/preferences" do
+    it "rejects unauthenticated requests" do
+      get "/me/preferences"
+
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    context "when the caller lacks roles" do
+      let(:unprivileged_user) { create(:user, roles: []) }
+      let(:unprivileged_headers) { authenticate_request_with_bearer!(unprivileged_user) }
+
+      before { get "/me/preferences", headers: unprivileged_headers }
+
+      it { expect(response).to have_http_status(:forbidden) }
+    end
+
+    it "returns ordered settings-visible categories with defaults" do
+      get "/me/preferences", headers: headers
+
+      expect(response).to have_http_status(:ok)
+      data = response.parsed_body["data"]
+      expect(data.keys).to contain_exactly("categories")
+      expect(data["categories"].map { |c| c["key"] }).to eq(%w[reservations account])
+      expect(data["categories"].flat_map { |c| c["notifications"].map { |n| n["key"] } }).not_to include("hello_world")
+
+      booking = data["categories"].first["notifications"].first
+      expect(booking).to include(
+        "key" => "booking_confirmation",
+        "allowedChannels" => %w[email sms],
+        "availableChannels" => ["email"],
+      )
+      expect(booking["preferences"]).to include(
+        "inboxEnabled" => true,
+        "storedOverridePresent" => false,
+      )
+    end
+
+    it "reflects stored overrides" do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key: "booking_confirmation",
+        preference_state: { "channels" => { "email" => false }, "inbox" => false },
+      )
+
+      get "/me/preferences", headers: headers
+
+      booking = response.parsed_body.dig("data", "categories", 0, "notifications", 0)
+      expect(booking["preferences"]).to include(
+        "inboxEnabled" => false,
+        "storedOverridePresent" => true,
+      )
+    end
+  end
+
+  describe "PATCH /me/preferences/:notification_type_key" do
+    it "updates preferences and returns the notification shape" do
+      patch "/me/preferences/booking_confirmation",
+            headers: headers,
+            params: { preferences: { inboxEnabled: false, channels: { email: false } } },
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      notification = response.parsed_body.dig("data", "notification")
+      expect(notification["key"]).to eq("booking_confirmation")
+      expect(notification["preferences"]).to include(
+        "inboxEnabled" => false,
+        "storedOverridePresent" => true,
+      )
+    end
+
+    it "resets to defaults when preferences is empty" do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key: "booking_confirmation",
+        preference_state: { "channels" => { "email" => false }, "inbox" => false },
+      )
+
+      patch "/me/preferences/booking_confirmation",
+            headers: headers,
+            params: { preferences: {} },
+            as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.dig("data", "notification", "preferences", "storedOverridePresent")).to eq(false)
+    end
+
+    it "returns not found for unknown types" do
+      patch "/me/preferences/missing_type",
+            headers: headers,
+            params: { preferences: { inboxEnabled: false } },
+            as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns not found for settings-hidden types" do
+      patch "/me/preferences/hello_world",
+            headers: headers,
+            params: { preferences: { inboxEnabled: false } },
+            as: :json
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it "returns unprocessable entity for non-configurable types" do
+      patch "/me/preferences/password_changed",
+            headers: headers,
+            params: { preferences: { channels: { email: false } } },
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns unprocessable entity for channels outside the allowed set" do
+      patch "/me/preferences/booking_confirmation",
+            headers: headers,
+            params: { preferences: { channels: { push: false } } },
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+
+    it "returns unprocessable entity for malformed bodies" do
+      patch "/me/preferences/booking_confirmation",
+            headers: headers,
+            params: { preferences: { mandatory: true } },
+            as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/command_tower/me/pushover_spec.rb
+++ b/spec/requests/command_tower/me/pushover_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+RSpec.describe "Me pushover", :with_rbac_setup, type: :request do
+  let(:user) { create(:user, roles: ["member"]) }
+  let(:headers) { authenticate_request_with_bearer!(user) }
+  let(:credentials) do
+    {
+      userKey: "pushover-user-key-abcd",
+      applicationToken: "pushover-app-token-zzzz"
+    }
+  end
+
+  let(:with_pushover_fake_adapter!) do
+    lambda do |&block|
+      previous = CommandTower.config.messaging.pushover.adapter
+      CommandTower.config.messaging.pushover.adapter = "fake"
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      block.call
+    ensure
+      CommandTower.config.messaging.pushover.adapter = previous
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+    end
+  end
+
+  before do
+    allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+  end
+
+  it "rejects unauthenticated show" do
+    get "/me/pushover"
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns unconfigured when no endpoint exists" do
+    get "/me/pushover", headers: headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.parsed_body["data"]).to include(
+      "configured" => false,
+      "actions" => {
+        "canCreate" => true,
+        "canVerify" => false,
+        "canReplace" => false,
+        "canRemove" => false
+      }
+    )
+  end
+
+  context "when managing pushover credentials end-to-end" do
+    around { |example| with_pushover_fake_adapter!.call { example.run } }
+
+    context "after creating credentials" do
+      before { post "/me/pushover", headers: headers, params: credentials, as: :json }
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it "returns configured unverified state without secrets" do
+        expect(response.parsed_body["data"]).to include(
+          "configured" => true,
+          "channelKey" => "pushover",
+          "verificationState" => "unverified"
+        )
+        expect(response.parsed_body["data"].to_json).not_to include("pushover-user-key")
+        expect(response.parsed_body["data"].to_json).not_to include("pushover-app-token")
+      end
+    end
+
+    context "after verifying credentials" do
+      before do
+        post "/me/pushover", headers: headers, params: credentials, as: :json
+        post "/me/pushover/verification", headers: headers, as: :json
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response.parsed_body.dig("data", "verificationState")).to eq("verified") }
+    end
+
+    context "after replacing via PUT" do
+      let(:original_id) do
+        post "/me/pushover", headers: headers, params: credentials, as: :json
+        response.parsed_body["data"]["id"]
+      end
+
+      before do
+        original_id
+        post "/me/pushover/verification", headers: headers, as: :json
+        put "/me/pushover",
+            headers: headers,
+            params: {
+              userKey: "pushover-user-key-efgh",
+              applicationToken: "pushover-app-token-yyyy"
+            },
+            as: :json
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+
+      it "creates a new endpoint in unverified state" do
+        expect(response.parsed_body["data"]["id"]).not_to eq(original_id)
+        expect(response.parsed_body["data"]["verificationState"]).to eq("unverified")
+      end
+    end
+
+    context "after patch and delete" do
+      before do
+        post "/me/pushover", headers: headers, params: credentials, as: :json
+        post "/me/pushover/verification", headers: headers, as: :json
+        put "/me/pushover",
+            headers: headers,
+            params: {
+              userKey: "pushover-user-key-efgh",
+              applicationToken: "pushover-app-token-yyyy"
+            },
+            as: :json
+        patch "/me/pushover",
+              headers: headers,
+              params: {
+                userKey: "pushover-user-key-ijkl",
+                applicationToken: "pushover-app-token-xxxx"
+              },
+              as: :json
+        delete "/me/pushover", headers: headers
+      end
+
+      it { expect(response).to have_http_status(:ok) }
+      it { expect(response.parsed_body.dig("data", "configured")).to eq(false) }
+    end
+  end
+
+  it "rejects missing credentials with 422" do
+    post "/me/pushover", headers: headers, params: { userKey: "" }, as: :json
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
+  it "maps conflict when already configured" do
+    with_pushover_fake_adapter!.call do
+      post "/me/pushover", headers: headers, params: credentials, as: :json
+      expect(response).to have_http_status(:ok)
+
+      post "/me/pushover",
+           headers: headers,
+           params: {
+             userKey: "pushover-user-key-efgh",
+             applicationToken: "pushover-app-token-yyyy"
+           },
+           as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("pushover_already_configured")
+    end
+  end
+
+  it "maps verification failures" do
+    with_pushover_fake_adapter!.call do
+      post "/me/pushover", headers: headers, params: credentials, as: :json
+
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_user
+      post "/me/pushover/verification", headers: headers, as: :json
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("pushover_invalid_user")
+
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :provider_unavailable
+      post "/me/pushover/verification", headers: headers, as: :json
+      expect(response).to have_http_status(:bad_gateway)
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("pushover_provider_unavailable")
+    end
+  end
+
+  context "when Pushover product gate is off" do
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+    end
+
+    it "returns service unavailable when Pushover product gate is off" do
+      get "/me/pushover", headers: headers
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.parsed_body.dig("errors", 0, "code")).to eq("pushover_capability_unavailable")
+    end
+
+    it "does not apply Engine Pushover route constraints" do
+      expect(CommandTower::Engine.routes.recognize_path("/me/pushover", method: :get)).to include(
+        controller: "command_tower/me/pushover",
+        action: "show"
+      )
+      expect(CommandTower::Engine.routes.recognize_path("/me/pushover", method: :put)).to include(
+        controller: "command_tower/me/pushover",
+        action: "update"
+      )
+      expect(CommandTower::Engine.routes.recognize_path("/me/pushover/verification", method: :post)).to include(
+        controller: "command_tower/me/pushover/verifications",
+        action: "create"
+      )
+    end
+  end
+end

--- a/spec/requests/command_tower/me_spec.rb
+++ b/spec/requests/command_tower/me_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+RSpec.describe "GET /me", :with_rbac_setup, type: :request do
+  subject(:make_request) { get path, headers: headers }
+
+  let(:path) { "/me" }
+  let(:headers) { {} }
+
+  context "without authentication" do
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unauthorized) }
+  end
+
+  context "with a valid Bearer token" do
+    let(:user) { create(:user, roles: ["member"], first_name: "Ada", last_name: "Lovelace") }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "returns the account payload" do
+      expect(response.parsed_body["data"]).to include(
+        "id" => user.id,
+        "firstName" => "Ada",
+        "lastName" => "Lovelace",
+        "fullName" => "Ada Lovelace",
+        "email" => user.email,
+        "username" => user.username,
+        "emailValidated" => true
+      )
+      expect(response.parsed_body["data"]["capabilities"]).to include(
+        "editName" => { "enabled" => true },
+        "changePassword" => { "enabled" => true },
+        "verifyEmail" => { "enabled" => false }
+      )
+      expect(response.parsed_body["data"]["createdAt"]).to be_present
+    end
+  end
+
+  context "without a role mapped onto the action" do
+    let(:user) { create(:user, roles: []) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:forbidden) }
+  end
+end

--- a/spec/requests/command_tower/profile_spec.rb
+++ b/spec/requests/command_tower/profile_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe "GET /profile", :with_rbac_setup, type: :request do
+  subject(:make_request) { get path, headers: headers }
+
+  let(:path) { "/profile" }
+  let(:headers) { {} }
+
+  context "without authentication" do
+    before { make_request }
+
+    it { expect(response).to have_http_status(:unauthorized) }
+  end
+
+  context "with a valid Bearer token" do
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:ok) }
+
+    it "returns the UserSerializer payload" do
+      expect(response.parsed_body["data"]).to include(
+        "id" => user.id,
+        "email" => user.email,
+        "username" => user.username,
+        "firstName" => user.first_name,
+        "lastName" => user.last_name,
+        "emailValidated" => true,
+        "roles" => ["member"]
+      )
+      expect(response.parsed_body["data"]).not_to have_key("fullName")
+      expect(response.parsed_body["data"]).not_to have_key("capabilities")
+    end
+  end
+
+  context "without a role mapped onto the action" do
+    let(:user) { create(:user, roles: []) }
+    let(:headers) { authenticate_request_with_bearer!(user) }
+
+    before { make_request }
+
+    it { expect(response).to have_http_status(:forbidden) }
+  end
+end

--- a/spec/serializers/command_tower/serializers/me/account_serializer_spec.rb
+++ b/spec/serializers/command_tower/serializers/me/account_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Serializers::Me::AccountSerializer do
+  describe ".serialize" do
+    subject(:payload) { described_class.serialize(user, capabilities: capabilities) }
+
+    let(:user) { create(:user, first_name: "Ada", last_name: "Lovelace", roles: ["member"]) }
+    let(:capabilities) { { editName: { enabled: true } } }
+
+    it "includes identity and account fields" do
+      expect(payload).to include(
+        id: user.id,
+        firstName: "Ada",
+        lastName: "Lovelace",
+        fullName: "Ada Lovelace",
+        username: user.username,
+        email: user.email,
+        emailValidated: true,
+        roles: ["member"],
+        capabilities: capabilities
+      )
+      expect(payload[:createdAt]).to be_present
+    end
+  end
+end

--- a/spec/serializers/command_tower/serializers/me/pushover_serializer_spec.rb
+++ b/spec/serializers/command_tower/serializers/me/pushover_serializer_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Serializers::Me::PushoverSerializer do
+  it "returns unconfigured payload for nil" do
+    expect(described_class.serialize(nil)).to eq(described_class.unconfigured)
+  end
+
+  context "with a safe view" do
+    let(:view) do
+      instance_double(
+        "SafeView",
+        id: 12,
+        channel_key: "pushover",
+        lifecycle_state: "active",
+        verification_state: "unverified",
+        masked_display_value: "****abcd",
+        credentials_configured: true,
+        verified_at: nil,
+        created_at: Time.utc(2026, 1, 2, 3, 4, 5),
+        updated_at: Time.utc(2026, 1, 2, 3, 4, 5)
+      )
+    end
+
+    subject(:payload) { described_class.serialize(view) }
+
+    it "serializes without secrets" do
+      expect(payload).to include(
+        configured: true,
+        id: 12,
+        channelKey: "pushover",
+        lifecycleState: "active",
+        verificationState: "unverified",
+        maskedDisplayValue: "****abcd",
+        credentialsConfigured: true
+      )
+      expect(payload[:actions]).to eq(
+        canCreate: false,
+        canVerify: true,
+        canReplace: true,
+        canRemove: true
+      )
+      expect(payload.to_json).not_to include("user_key")
+      expect(payload.to_json).not_to include("application_token")
+    end
+  end
+end

--- a/spec/serializers/command_tower/serializers/messaging/inbox_spec.rb
+++ b/spec/serializers/command_tower/serializers/messaging/inbox_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Serializers::Messaging::Inbox::ItemSerializer do
+  subject(:payload) do
+    described_class.serialize(
+      id: 1, title: "Notice", status: "created", viewed_at: nil,
+      created_at: Time.zone.parse("2026-01-01 12:00:00"), updated_at: Time.zone.parse("2026-01-01 12:00:00")
+    )
+  end
+
+  it "uses the modern inbox response keys" do
+    expect(payload).to include(id: 1, read: false, viewedAt: nil)
+  end
+end

--- a/spec/serializers/command_tower/serializers/messaging/preferences/notification_serializer_spec.rb
+++ b/spec/serializers/command_tower/serializers/messaging/preferences/notification_serializer_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Serializers::Messaging::Preferences::NotificationSerializer do
+  let(:notification) do
+    instance_double(
+      "CatalogNotification",
+      key: "booking_confirmation",
+      label: "Booking Confirmation",
+      description: nil,
+      order: 10,
+      configurable: true,
+      mandatory: false,
+      inbox_available: true,
+      allowed_channels: %w[email sms],
+      available_channels: %w[email],
+      inbox_enabled: true,
+      channels: { "email" => true, "sms" => false },
+      stored_override_present: false,
+    )
+  end
+
+  it "serializes the camelCase notification contract" do
+    expect(described_class.serialize(notification)).to eq(
+      key: "booking_confirmation",
+      label: "Booking Confirmation",
+      description: nil,
+      order: 10,
+      configurable: true,
+      mandatory: false,
+      inboxAvailable: true,
+      allowedChannels: %w[email sms],
+      availableChannels: %w[email],
+      preferences: {
+        inboxEnabled: true,
+        channels: { "email" => true, "sms" => false },
+        storedOverridePresent: false,
+      },
+    )
+  end
+end

--- a/spec/services/command_tower/identity/phone/normalizer_spec.rb
+++ b/spec/services/command_tower/identity/phone/normalizer_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Identity::Phone::Normalizer do
+  describe ".call" do
+    subject(:call) { described_class.call(phone_number:) }
+
+    context "with a valid E.164 number" do
+      let(:phone_number) { "+1 (415) 555-2671" }
+
+      it "succeeds" do
+        expect(call).to be_success
+      end
+
+      it "normalizes to E.164" do
+        expect(call.normalized).to eq("+14155552671")
+      end
+    end
+
+    context "with a US national number without +" do
+      let(:phone_number) { "4155552671" }
+
+      it "normalizes using default country US" do
+        expect(call).to be_success
+        expect(call.normalized).to eq("+14155552671")
+      end
+    end
+
+    context "with blank input" do
+      let(:phone_number) { "   " }
+
+      it "fails" do
+        expect(call).to be_failure
+      end
+
+      it "explains that a number is required" do
+        expect(call.message).to eq(described_class::BLANK_MESSAGE)
+        expect(call.normalized).to be_nil
+      end
+    end
+
+    context "with unparseable input" do
+      let(:phone_number) { "not-a-phone" }
+
+      it "fails" do
+        expect(call).to be_failure
+      end
+
+      it "explains that the number is invalid" do
+        expect(call.message).to eq(described_class::INVALID_MESSAGE)
+        expect(call.normalized).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/identity/phone_verification/sms_configuration_spec.rb
+++ b/spec/services/command_tower/identity/phone_verification/sms_configuration_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Identity::PhoneVerification::SmsConfiguration do
+  let(:with_phone_verification) do
+    lambda do |enable:, sms_adapter:, sms_from: nil, &block|
+      config = CommandTower.config.identity.phone_verification
+      previous = {
+        enable: config.enable,
+        sms_adapter: config.sms_adapter,
+        sms_from: config.sms_from
+      }
+      config.enable = enable
+      config.sms_adapter = sms_adapter
+      config.sms_from = sms_from
+      block.call
+    ensure
+      config.enable = previous[:enable]
+      config.sms_adapter = previous[:sms_adapter]
+      config.sms_from = previous[:sms_from]
+    end
+  end
+
+  it "is not ready when phone verification is disabled" do
+    with_phone_verification.call(enable: false, sms_adapter: "fake") do
+      expect(described_class.sms_ready?).to eq(false)
+    end
+  end
+
+  context "when running in a test environment" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("test"))
+    end
+
+    it "is ready for fake adapter outside production" do
+      with_phone_verification.call(enable: true, sms_adapter: "fake") do
+        expect(described_class.sms_ready?).to eq(true)
+      end
+    end
+  end
+
+  context "when running in a development environment" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+    end
+
+    it "is ready for log adapter outside production" do
+      with_phone_verification.call(enable: true, sms_adapter: "log") do
+        expect(described_class.sms_ready?).to eq(true)
+      end
+    end
+  end
+
+  context "when running in a production environment" do
+    before do
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("production"))
+    end
+
+    it "is not ready for fake adapter in production" do
+      with_phone_verification.call(enable: true, sms_adapter: "fake") do
+        expect(described_class.sms_ready?).to eq(false)
+      end
+    end
+  end
+
+  it "is ready for twilio when credentials and from are present" do
+    with_phone_verification.call(enable: true, sms_adapter: "twilio", sms_from: "+15551234567") do
+      with_env(
+        "TWILIO_ACCOUNT_SID" => "ACxxx",
+        "TWILIO_AUTH_TOKEN" => "secret"
+      ) do
+        expect(described_class.sms_ready?).to eq(true)
+      end
+    end
+  end
+
+  it "is ready for twilio when from comes from TWILIO_FROM" do
+    with_phone_verification.call(enable: true, sms_adapter: "twilio", sms_from: nil) do
+      with_env(
+        "TWILIO_ACCOUNT_SID" => "ACxxx",
+        "TWILIO_AUTH_TOKEN" => "secret",
+        "TWILIO_FROM" => "+15551234567",
+        "TWILIO_FROM_NUMBER" => nil
+      ) do
+        expect(described_class.sms_ready?).to eq(true)
+      end
+    end
+  end
+
+  it "is ready for twilio when from comes from TWILIO_FROM_NUMBER" do
+    with_phone_verification.call(enable: true, sms_adapter: "twilio", sms_from: nil) do
+      with_env(
+        "TWILIO_ACCOUNT_SID" => "ACxxx",
+        "TWILIO_AUTH_TOKEN" => "secret",
+        "TWILIO_FROM" => nil,
+        "TWILIO_FROM_NUMBER" => "+15551234567"
+      ) do
+        expect(described_class.sms_ready?).to eq(true)
+      end
+    end
+  end
+
+  it "is not ready for twilio when credentials are incomplete" do
+    with_phone_verification.call(enable: true, sms_adapter: "twilio", sms_from: "+15551234567") do
+      with_env(
+        "TWILIO_ACCOUNT_SID" => "ACxxx",
+        "TWILIO_AUTH_TOKEN" => nil,
+        "TWILIO_FROM" => nil
+      ) do
+        expect(described_class.sms_ready?).to eq(false)
+      end
+    end
+  end
+
+  context "when rejecting unknown adapters at configure time" do
+    let(:config) { CommandTower.config.identity.phone_verification }
+    let(:previous) { config.sms_adapter }
+
+    after { config.sms_adapter = previous }
+
+    it "raises like Messaging SMS validation" do
+      expect {
+        config.sms_adapter = "unknown"
+      }.to raise_error(ClassComposer::ValidatorError, /Allowed: fake, log, twilio/)
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/execution/adapters/pushover/adapter_spec.rb
+++ b/spec/services/command_tower/messaging/execution/adapters/pushover/adapter_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Execution::Adapters::Pushover::Adapter, :messaging_accept do
+  let(:user) { create(:user) }
+  let(:communication) do
+    create(
+      :messaging_communication,
+      user:,
+      host_event_identity: "pushover-adapter-#{SecureRandom.hex(4)}",
+      accept_request_fingerprint: "fp",
+      status: "accepted",
+      execution_handoff_status: "enqueued",
+      title: "Hello",
+      body: "World",
+    )
+  end
+  let(:delivery) do
+    create(
+      :messaging_channel_delivery,
+      communication:,
+      channel_key: "pushover",
+      status: "queued",
+    )
+  end
+  let(:endpoint) do
+    view = CommandTower::Messaging::Endpoints.create(
+      owner_user_id: user.id,
+      channel_key: "pushover",
+      credentials: {
+        user_key: "u" + ("a" * 30),
+        application_token: "t" + ("b" * 30),
+      },
+    )
+    record = CommandTower::Messaging::Endpoint.find(view.id)
+    record.update!(verification_state: "verified", verified_at: Time.current)
+    record
+  end
+
+  let(:build_request) do
+    lambda do |endpoint_id: endpoint.id|
+      rendered = CommandTower::Messaging::Rendering::RenderedPushoverPayload.build(
+        recipient_address: endpoint_id.to_s,
+        title: "Hello",
+        message: "World",
+      )
+      CommandTower::Messaging::Execution::AdapterRequest.build(
+        channel_delivery_id: delivery.id,
+        communication_id: communication.id,
+        channel_key: "pushover",
+        attempt_id: 3,
+        rendered:,
+      )
+    end
+  end
+
+  let(:configured) do
+    instance_double(
+      CommandTower::Messaging::Execution::Adapters::Pushover::Configuration,
+      pushover_configured?: true,
+    )
+  end
+
+  around do |example|
+    previous = CommandTower.config.messaging.pushover.adapter
+    CommandTower.config.messaging.pushover.adapter = "fake"
+    CommandTower::Messaging::Pushover::Transport.reset_adapter!
+    CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+    example.run
+  ensure
+    CommandTower.config.messaging.pushover.adapter = previous
+    CommandTower::Messaging::Pushover::Transport.reset_adapter!
+    CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+  end
+
+  context "with a successful send" do
+    subject(:result) { described_class.new(configuration: configured).call(request: build_request.call) }
+
+    it "sends through Transport and maps success with safe provider metadata" do
+      expect(result.success?).to eq(true)
+      expect(result.normalized_provider_status).to eq("accepted")
+      expect(result.provider_message_id).to be_present
+      expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages.size).to eq(1)
+    end
+  end
+
+  context "when the transport times out" do
+    before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :timeout }
+
+    subject(:result) { described_class.new(configuration: configured).call(request: build_request.call) }
+
+    it "maps timeout to retryable without mark_invalid" do
+      expect(CommandTower::Messaging::Endpoints).not_to receive(:mark_invalid)
+      expect(result.retryable_failure?).to eq(true)
+      expect(result.error_code).to eq("pushover_transient")
+    end
+  end
+
+  context "when credentials are invalid" do
+    before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_user }
+
+    subject(:result) { described_class.new(configuration: configured).call(request: build_request.call) }
+
+    it "maps invalid credentials to terminal and marks endpoint invalid" do
+      expect(CommandTower::Messaging::Endpoints).to receive(:mark_invalid).with(
+        owner_user_id: user.id,
+        endpoint_id: endpoint.id,
+      ).and_call_original
+      expect(result.terminal_failure?).to eq(true)
+      expect(result.error_code).to eq("pushover_rejected")
+      expect(endpoint.reload.lifecycle_state).to eq("invalid")
+    end
+  end
+
+  context "during delivery" do
+    subject(:invoke) { described_class.new(configuration: configured).call(request: build_request.call) }
+
+    it "does not call verify_pushover! during delivery" do
+      expect(CommandTower::Messaging::Endpoints).not_to receive(:verify_pushover!)
+      invoke
+    end
+  end
+
+  context "when not configured" do
+    let(:unconfigured_config) do
+      instance_double(
+        CommandTower::Messaging::Execution::Adapters::Pushover::Configuration,
+        pushover_configured?: false,
+      )
+    end
+
+    subject(:result) { described_class.new(configuration: unconfigured_config).call(request: build_request.call) }
+
+    it "returns adapter_unconfigured when not configured" do
+      expect(result.terminal_failure?).to eq(true)
+      expect(result.error_code).to eq("adapter_unconfigured")
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/execution/adapters/pushover/configuration_spec.rb
+++ b/spec/services/command_tower/messaging/execution/adapters/pushover/configuration_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Execution::Adapters::Pushover::Configuration do
+  around do |example|
+    previous = CommandTower.config.messaging.pushover.adapter
+    example.run
+  ensure
+    CommandTower.config.messaging.pushover.adapter = previous
+  end
+
+  %w[fake log http].each do |adapter_name|
+    context "with the #{adapter_name} adapter" do
+      before { CommandTower.config.messaging.pushover.adapter = adapter_name }
+
+      it "is configured" do
+        expect(described_class.pushover_configured?).to be(true)
+      end
+    end
+  end
+
+  context "when disabled" do
+    before { CommandTower.config.messaging.pushover.adapter = "disabled" }
+
+    it "is not configured when disabled" do
+      expect(described_class.pushover_configured?).to be(false)
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/preferences/catalog_spec.rb
+++ b/spec/services/command_tower/messaging/preferences/catalog_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Preferences::Catalog, :messaging_preferences do
+  let(:user) { create(:user) }
+  let(:platform_enabled_channels) { %w[email] }
+
+  let(:catalog) do
+    described_class.call(
+      recipient_id: user.id,
+      platform_enabled_channels:,
+    )
+  end
+
+  describe "ordering and visibility" do
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: "promo.announcement",
+          label: "Promo",
+          category_key: "marketing",
+          category_label: "Marketing",
+          category_order: 40,
+          type_order: 10,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          settings_visible: true,
+        ),
+        build_notification_type_declaration(
+          key: "booking.confirmation",
+          label: "Booking Confirmation",
+          category_key: "reservations",
+          category_label: "Reservations",
+          category_order: 10,
+          type_order: 20,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          settings_visible: true,
+        ),
+        build_notification_type_declaration(
+          key: "booking.cancellation",
+          label: "Booking Cancellation",
+          category_key: "reservations",
+          category_label: "Reservations",
+          category_order: 10,
+          type_order: 10,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          settings_visible: true,
+        ),
+        build_notification_type_declaration(
+          key: "hello_world",
+          label: "Hello World",
+          category_key: "development",
+          category_label: "Development",
+          category_order: 1000,
+          type_order: 10,
+          allowed_channels: [],
+          default_channels: [],
+          user_configurable: false,
+          settings_visible: false,
+          default_preference_state: {
+            "channels" => {},
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    subject(:result) { catalog }
+
+    it "preserves registry category and notification ordering" do
+      expect(result.categories.map(&:key)).to eq(%w[reservations marketing])
+      expect(result.categories.first.notifications.map(&:key)).to eq(
+        %w[booking.cancellation booking.confirmation],
+      )
+    end
+
+    it "excludes settings_visible false notifications and drops empty categories" do
+      expect(result.categories.flat_map { |category| category.notifications.map(&:key) }).not_to include("hello_world")
+      expect(result.categories.map(&:key)).not_to include("development")
+    end
+
+    it "sets category description to nil" do
+      expect(result.categories.first.description).to be_nil
+    end
+  end
+
+  describe "effective preference mapping" do
+    let(:notification_type_key) { "booking.success" }
+
+    let(:notification) do
+      catalog.categories
+        .flat_map(&:notifications)
+        .find { |entry| entry.key == notification_type_key }
+    end
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: "booking.success",
+          allowed_channels: %w[email sms],
+          default_channels: %w[email],
+          inbox_available: true,
+          user_configurable: true,
+          mandatory: false,
+          default_preference_state: {
+            "channels" => { "email" => true, "sms" => true },
+            "inbox" => true,
+          },
+          settings_visible: true,
+        ),
+        build_notification_type_declaration(
+          key: "password.changed",
+          label: "Password Changed",
+          category_key: "account",
+          category_label: "Account",
+          category_order: 30,
+          type_order: 10,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          user_configurable: false,
+          mandatory: true,
+          settings_visible: true,
+          default_preference_state: {
+            "channels" => { "email" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    it "maps declaration defaults when no stored override exists" do
+      expect(notification.stored_override_present).to be(false)
+      expect(notification.inbox_enabled).to be(true)
+      expect(notification.channels).to eq("email" => true, "sms" => true)
+      expect(notification.available_channels).to eq(["email"])
+      expect(notification.allowed_channels).to eq(%w[email sms])
+      expect(notification.configurable).to be(true)
+      expect(notification.mandatory).to be(false)
+    end
+
+    context "when email is not validated" do
+      before { user.update!(email_validated: false) }
+
+      it "intersects available_channels with recipient_ready" do
+        expect(notification.available_channels).to eq([])
+      end
+    end
+
+    context "with a stored override" do
+      before do
+        CommandTower::Messaging::Preferences.upsert_stored!(
+          recipient_id: user.id,
+          notification_type_key:,
+          preference_state: build_preference_state(channels: { "email" => false }, inbox: false),
+        )
+      end
+
+      it "maps stored overrides through Resolve" do
+        expect(notification.stored_override_present).to be(true)
+        expect(notification.inbox_enabled).to be(false)
+        expect(notification.channels).to eq("email" => false, "sms" => true)
+      end
+    end
+
+    context "for a mandatory non-configurable type" do
+      let(:notification_type_key) { "password.changed" }
+
+      it "exposes mandatory and non-configurable presentation flags" do
+        expect(notification.configurable).to be(false)
+        expect(notification.mandatory).to be(true)
+        expect(notification.stored_override_present).to be(false)
+      end
+    end
+
+    it "returns an immutable catalog result" do
+      expect(catalog).to be_frozen
+      expect(catalog.categories).to be_frozen
+      expect(catalog.categories.first).to be_frozen
+      expect(catalog.categories.first.notifications).to be_frozen
+    end
+
+    context "when Store raises" do
+      before do
+        allow(CommandTower::Messaging::Preferences::Store).to receive(:find).and_raise(
+          CommandTower::Messaging::Preferences::StoreError,
+          "db down",
+        )
+      end
+
+      it "fails closed when Store raises" do
+        expect { catalog }.to raise_error(CommandTower::Messaging::Preferences::StoreError)
+      end
+    end
+  end
+
+  describe "Preferences.catalog façade" do
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(settings_visible: true),
+      )
+    end
+
+    subject(:result) do
+      CommandTower::Messaging::Preferences.catalog(
+        recipient_id: user.id,
+        platform_enabled_channels: [],
+      )
+    end
+
+    it "delegates to Catalog" do
+      expect(result).to be_a(CommandTower::Messaging::Preferences::CatalogResult)
+      expect(result.categories.length).to eq(1)
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/preferences/evaluator_spec.rb
+++ b/spec/services/command_tower/messaging/preferences/evaluator_spec.rb
@@ -1,0 +1,290 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Preferences::Evaluator, :messaging_preferences do
+  let(:recipient_id) { 42 }
+  let(:platform_enabled_channels) { %w[email sms push] }
+  let(:preference_state) { nil }
+
+  let(:evaluate) do
+    described_class.call(
+      notification_type_key:,
+      recipient_id:,
+      preference_state:,
+      platform_enabled_channels:,
+    )
+  end
+
+  describe "unknown type" do
+    let(:notification_type_key) { "unknown.type" }
+
+    it "fails closed with UnknownTypeError" do
+      expect { evaluate }.to raise_error(
+        CommandTower::Messaging::Preferences::UnknownTypeError,
+      )
+    end
+  end
+
+  context "with a registered optional user-configurable type" do
+    let(:notification_type_key) { "booking.success" }
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: notification_type_key,
+          allowed_channels: %w[email sms],
+          default_channels: %w[email],
+          inbox_available: true,
+          user_configurable: true,
+          mandatory: false,
+          default_preference_state: {
+            "channels" => { "email" => true, "sms" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    context "when preference_state is absent" do
+      subject(:result) { evaluate }
+
+      it "applies declaration defaults when preference_state is absent" do
+        expect(result.notification_type_key).to eq("booking.success")
+        expect(result.recipient_id).to eq(42)
+        expect(result.permitted_channels).to contain_exactly("email", "sms")
+        expect(result.inbox_permitted).to be(true)
+        expect(result.mandatory).to be(false)
+        expect(result.mandatory_enforced).to be(false)
+        expect(result.suppressed_destinations).to be_empty
+      end
+    end
+
+    context "when recipient preference disables a channel" do
+      let(:preference_state) do
+        build_preference_state(
+          channels: { "email" => true, "sms" => false },
+          inbox: true,
+        )
+      end
+
+      subject(:result) { evaluate }
+
+      it "suppresses channels disabled by recipient preference" do
+        expect(result.permitted_channels).to eq(["email"])
+        expect(result.suppressed_destinations).to contain_exactly(
+          have_attributes(
+            destination: "sms",
+            reason_class: CommandTower::Messaging::Preferences::ReasonClasses::SUPPRESSED_BY_PREFERENCE,
+          ),
+        )
+      end
+    end
+
+    context "when all channels and inbox are disabled" do
+      let(:preference_state) do
+        build_preference_state(
+          channels: { "email" => false, "sms" => false },
+          inbox: false,
+        )
+      end
+
+      subject(:result) { evaluate }
+
+      it "allows an empty permitted set for optional types" do
+        expect(result.permitted_channels).to be_empty
+        expect(result.inbox_permitted).to be(false)
+        expect(result.suppressed_destinations.map(&:destination)).to contain_exactly("email", "sms", :inbox)
+      end
+    end
+
+    context "when a channel is not platform-enabled" do
+      let(:platform_enabled_channels) { %w[email] }
+
+      subject(:result) { evaluate }
+
+      it "skips channels that are not platform-enabled" do
+        expect(result.permitted_channels).to eq(["email"])
+        expect(result.suppressed_destinations).to contain_exactly(
+          have_attributes(
+            destination: "sms",
+            reason_class: CommandTower::Messaging::Preferences::ReasonClasses::SKIPPED_BY_POLICY,
+          ),
+        )
+      end
+    end
+
+    context "when preference includes channels outside the allowed set" do
+      let(:preference_state) do
+        build_preference_state(
+          channels: { "email" => true, "push" => true },
+          inbox: true,
+        )
+      end
+
+      subject(:result) { evaluate }
+
+      it "never permits channels outside the type allowed set" do
+        expect(result.permitted_channels).to include("email")
+        expect(result.permitted_channels).not_to include("push")
+        expect(result.suppressed_destinations).to include(
+          have_attributes(
+            destination: "push",
+            reason_class: CommandTower::Messaging::Preferences::ReasonClasses::SKIPPED_BY_POLICY,
+          ),
+        )
+      end
+    end
+  end
+
+  context "with a mandatory type" do
+    let(:notification_type_key) { "security.alert" }
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: notification_type_key,
+          allowed_channels: %w[email sms],
+          default_channels: %w[email],
+          inbox_available: true,
+          user_configurable: true,
+          mandatory: true,
+          default_preference_state: {
+            "channels" => { "email" => true, "sms" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    context "when recipient preference disables required destinations" do
+      let(:preference_state) do
+        build_preference_state(
+          channels: { "email" => false, "sms" => false },
+          inbox: false,
+        )
+      end
+
+      subject(:result) { evaluate }
+
+      it "enforces required posture and sets mandatory_enforced" do
+        expect(result.mandatory).to be(true)
+        expect(result.mandatory_enforced).to be(true)
+        expect(result.permitted_channels).to include("email")
+        expect(result.inbox_permitted).to be(true)
+        expect(result.suppressed_destinations.map(&:destination)).to contain_exactly("sms")
+      end
+    end
+  end
+
+  context "with a non-user-configurable type" do
+    let(:notification_type_key) { "system.notice" }
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: notification_type_key,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          inbox_available: true,
+          user_configurable: false,
+          mandatory: false,
+          default_preference_state: {
+            "channels" => { "email" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    context "when recipient preference overrides defaults" do
+      let(:preference_state) do
+        build_preference_state(
+          channels: { "email" => false },
+          inbox: false,
+        )
+      end
+
+      subject(:result) { evaluate }
+
+      it "ignores recipient preference overrides" do
+        expect(result.permitted_channels).to eq(["email"])
+        expect(result.inbox_permitted).to be(true)
+        expect(result.suppressed_destinations).to be_empty
+      end
+    end
+  end
+
+  context "when inbox is not available on the type" do
+    let(:notification_type_key) { "channel.only" }
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: notification_type_key,
+          allowed_channels: %w[email],
+          default_channels: %w[email],
+          inbox_available: false,
+          user_configurable: true,
+          mandatory: false,
+          default_preference_state: {
+            "channels" => { "email" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    context "when prefs request inbox" do
+      let(:preference_state) { build_preference_state(channels: { "email" => true }, inbox: true) }
+
+      subject(:result) { evaluate }
+
+      it "does not permit inbox even when prefs request it" do
+        expect(result.inbox_permitted).to be(false)
+        expect(result.suppressed_destinations.map(&:destination)).not_to include(:inbox)
+      end
+    end
+  end
+
+  describe "malformed preference state" do
+    let(:notification_type_key) { "booking.success" }
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(key: notification_type_key),
+      )
+    end
+
+    it "raises InvalidPreferenceStateError" do
+      expect {
+        described_class.call(
+          notification_type_key:,
+          recipient_id:,
+          preference_state: "nope",
+          platform_enabled_channels:,
+        )
+      }.to raise_error(CommandTower::Messaging::Preferences::InvalidPreferenceStateError)
+    end
+  end
+end
+
+RSpec.describe CommandTower::Messaging::Preferences, :messaging_preferences do
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(key: "facade.type"),
+    )
+  end
+
+  subject(:result) do
+    described_class.evaluate(
+      notification_type_key: "facade.type",
+      recipient_id: 1,
+      preference_state: nil,
+      platform_enabled_channels: %w[email sms],
+    )
+  end
+
+  it "exposes evaluate on the module façade" do
+    expect(result).to be_a(CommandTower::Messaging::Preferences::EvaluationResult)
+    expect(result.permitted_channels).to include("email")
+  end
+end

--- a/spec/services/command_tower/messaging/preferences/resolve_spec.rb
+++ b/spec/services/command_tower/messaging/preferences/resolve_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Preferences::Resolve, :messaging_preferences do
+  let(:user) { create(:user) }
+  let(:notification_type_key) { "booking.success" }
+  let(:platform_enabled_channels) { %w[email sms] }
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: true,
+        mandatory: false,
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      ),
+    )
+  end
+
+  let(:resolve) do
+    described_class.call(
+      notification_type_key:,
+      recipient_id: user.id,
+      platform_enabled_channels:,
+    )
+  end
+
+  context "with declaration defaults and no stored preference" do
+    subject(:result) { resolve }
+
+    it "uses declaration defaults when no stored preference exists" do
+      expect(result.stored_override_present).to be(false)
+      expect(result.permitted_channels).to contain_exactly("email", "sms")
+      expect(result.inbox_permitted).to be(true)
+      expect(result.effective_preference_state["channels"]).to include("email" => true)
+    end
+  end
+
+  context "with a stored channel disable override" do
+    before do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "email" => false }, inbox: true),
+      )
+    end
+
+    subject(:result) { resolve }
+
+    it "applies a stored channel disable override" do
+      expect(result.stored_override_present).to be(true)
+      expect(result.permitted_channels).to eq(["sms"])
+      expect(result.inbox_permitted).to be(true)
+    end
+  end
+
+  context "with a partial override" do
+    before do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "sms" => false }),
+      )
+    end
+
+    subject(:result) { resolve }
+
+    it "preserves defaults for channels omitted from a partial override" do
+      expect(result.permitted_channels).to eq(["email"])
+      expect(result.effective_preference_state["channels"]).to include(
+        "email" => true,
+        "sms" => false,
+      )
+    end
+  end
+
+  context "when evaluating immutability" do
+    subject(:result) { resolve }
+
+    it "returns an immutable evaluation result" do
+      expect(result).to be_frozen
+      expect(result.permitted_channels).to be_frozen
+      expect(result.effective_preference_state).to be_frozen
+    end
+  end
+
+  context "with an unknown notification type" do
+    subject(:invoke) do
+      described_class.call(
+        notification_type_key: "missing.type",
+        recipient_id: user.id,
+        platform_enabled_channels:,
+      )
+    end
+
+    it "fails closed for an unknown notification type" do
+      expect { invoke }.to raise_error(CommandTower::Messaging::Preferences::UnknownTypeError)
+    end
+  end
+
+  context "with a newly registered type and no existing rows" do
+    before do
+      CommandTower::Messaging::NotificationTypes.reset!
+      register_and_seal_notification_types(
+        build_notification_type_declaration(key: "brand.new.type"),
+      )
+    end
+
+    subject(:result) do
+      described_class.call(
+        notification_type_key: "brand.new.type",
+        recipient_id: user.id,
+        platform_enabled_channels: %w[email sms],
+      )
+    end
+
+    it "works for a newly registered type with no existing rows" do
+      expect(result.stored_override_present).to be(false)
+      expect(result.permitted_channels).to include("email")
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/preferences/store_spec.rb
+++ b/spec/services/command_tower/messaging/preferences/store_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Preferences::Store, :messaging_preferences do
+  let(:user) { create(:user) }
+  let(:notification_type_key) { "booking.success" }
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: true,
+        mandatory: false,
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      ),
+      build_notification_type_declaration(
+        key: "password.changed",
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: false,
+        mandatory: true,
+        default_preference_state: {
+          "channels" => { "email" => true },
+          "inbox" => true,
+        },
+        label: "Password Changed",
+        category_key: "account",
+        category_label: "Account",
+        category_order: 30,
+        type_order: 10,
+      ),
+    )
+  end
+
+  describe ".find" do
+    it "returns nil when no row exists" do
+      expect(
+        described_class.find(recipient_id: user.id, notification_type_key:),
+      ).to be_nil
+    end
+
+    it "returns a PreferenceState for a stored sparse override" do
+      described_class.upsert!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "email" => false }, inbox: true),
+      )
+
+      found = described_class.find(recipient_id: user.id, notification_type_key:)
+      expect(found).to be_a(CommandTower::Messaging::Preferences::PreferenceState)
+      expect(found.channels).to eq("email" => false)
+      expect(found.inbox).to be(true)
+    end
+
+    context "with corrupt stored JSON" do
+      before do
+        CommandTower::Messaging::NotificationPreference.create!(
+          user_id: user.id,
+          notification_type_key:,
+          state: { "channels" => "bad" },
+        )
+      end
+
+      it "raises InvalidPreferenceStateError" do
+        expect {
+          described_class.find(recipient_id: user.id, notification_type_key:)
+        }.to raise_error(CommandTower::Messaging::Preferences::InvalidPreferenceStateError)
+      end
+    end
+  end
+
+  describe ".upsert!" do
+    it "creates and updates a unique preference row" do
+      described_class.upsert!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "email" => false }),
+      )
+      described_class.upsert!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "sms" => false }, inbox: false),
+      )
+
+      expect(CommandTower::Messaging::NotificationPreference.count).to eq(1)
+      found = described_class.find(recipient_id: user.id, notification_type_key:)
+      expect(found.channels).to eq("sms" => false)
+      expect(found.inbox).to be(false)
+    end
+
+    it "rejects unknown notification types" do
+      expect {
+        described_class.upsert!(
+          recipient_id: user.id,
+          notification_type_key: "missing.type",
+          preference_state: build_preference_state(channels: { "email" => true }),
+        )
+      }.to raise_error(CommandTower::Messaging::Preferences::UnknownTypeError)
+    end
+
+    it "rejects non-user-configurable types" do
+      expect {
+        described_class.upsert!(
+          recipient_id: user.id,
+          notification_type_key: "password.changed",
+          preference_state: build_preference_state(channels: { "email" => false }),
+        )
+      }.to raise_error(
+        CommandTower::Messaging::Preferences::InvalidPreferenceWriteError,
+        /not user-configurable/,
+      )
+    end
+
+    it "rejects channels outside the allowed set" do
+      expect {
+        described_class.upsert!(
+          recipient_id: user.id,
+          notification_type_key:,
+          preference_state: build_preference_state(channels: { "push" => true }),
+        )
+      }.to raise_error(
+        CommandTower::Messaging::Preferences::InvalidPreferenceWriteError,
+        /outside allowed set/,
+      )
+    end
+
+    it "enforces uniqueness at the database" do
+      described_class.upsert!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "email" => false }),
+      )
+
+      expect {
+        CommandTower::Messaging::NotificationPreference.create!(
+          user_id: user.id,
+          notification_type_key:,
+          state: { "channels" => { "email" => true } },
+        )
+      }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  describe ".delete!" do
+    it "removes an existing preference row" do
+      described_class.upsert!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: build_preference_state(channels: { "email" => false }),
+      )
+
+      described_class.delete!(recipient_id: user.id, notification_type_key:)
+
+      expect(
+        described_class.find(recipient_id: user.id, notification_type_key:),
+      ).to be_nil
+      expect(CommandTower::Messaging::NotificationPreference.count).to eq(0)
+    end
+
+    it "is a no-op when no row exists" do
+      expect {
+        described_class.delete!(recipient_id: user.id, notification_type_key:)
+      }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/preferences/update_spec.rb
+++ b/spec/services/command_tower/messaging/preferences/update_spec.rb
@@ -1,0 +1,334 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Messaging::Preferences::Update, :messaging_preferences do
+  let(:user) { create(:user) }
+  let(:notification_type_key) { "booking.success" }
+  let(:platform_enabled_channels) { %w[email sms] }
+
+  let(:update!) do
+    lambda do |preference_state:|
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state:,
+        platform_enabled_channels:,
+      )
+    end
+  end
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: true,
+        mandatory: false,
+        settings_visible: true,
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      ),
+      build_notification_type_declaration(
+        key: "password.changed",
+        label: "Password Changed",
+        category_key: "account",
+        category_label: "Account",
+        category_order: 30,
+        type_order: 10,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        user_configurable: false,
+        mandatory: true,
+        settings_visible: true,
+        default_preference_state: {
+          "channels" => { "email" => true },
+          "inbox" => true,
+        },
+      ),
+      build_notification_type_declaration(
+        key: "hello_world",
+        label: "Hello World",
+        category_key: "development",
+        category_label: "Development",
+        category_order: 1000,
+        type_order: 10,
+        allowed_channels: [],
+        default_channels: [],
+        user_configurable: true,
+        settings_visible: false,
+        default_preference_state: {
+          "channels" => {},
+          "inbox" => true,
+        },
+      ),
+      build_notification_type_declaration(
+        key: "security.alert",
+        label: "Security Alert",
+        category_key: "account",
+        category_label: "Account",
+        category_order: 30,
+        type_order: 20,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        user_configurable: true,
+        mandatory: true,
+        settings_visible: true,
+        default_preference_state: {
+          "channels" => { "email" => true },
+          "inbox" => true,
+        },
+      ),
+      build_notification_type_declaration(
+        key: "inbox.only",
+        label: "Inbox Only",
+        category_key: "account",
+        category_label: "Account",
+        category_order: 30,
+        type_order: 30,
+        allowed_channels: [],
+        default_channels: [],
+        inbox_available: false,
+        user_configurable: true,
+        settings_visible: true,
+        default_preference_state: {
+          "channels" => {},
+          "inbox" => nil,
+        },
+      ),
+    )
+  end
+
+  context "when updating preferences" do
+    subject(:result) do
+      update!.call(preference_state: { "channels" => { "email" => false }, "inbox" => true })
+    end
+
+    let(:stored) do
+      result
+      CommandTower::Messaging::Preferences.find_stored(
+        recipient_id: user.id,
+        notification_type_key:,
+      )
+    end
+
+    it "updates preferences and returns a catalog notification result" do
+      expect(result).to be_a(CommandTower::Messaging::Preferences::CatalogNotificationResult)
+      expect(result.key).to eq(notification_type_key)
+      expect(result.channels).to eq("email" => false, "sms" => true)
+      expect(result.inbox_enabled).to be(true)
+      expect(result.stored_override_present).to be(true)
+      expect(stored.to_raw_hash).to eq("channels" => { "email" => false })
+    end
+  end
+
+  context "when replacing a prior stored override" do
+    before do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: { "channels" => { "email" => false, "sms" => false }, "inbox" => false },
+      )
+      update!.call(preference_state: { "channels" => { "email" => false } })
+    end
+
+    let(:stored) do
+      CommandTower::Messaging::Preferences.find_stored(
+        recipient_id: user.id,
+        notification_type_key:,
+      )
+    end
+
+    it "replaces the prior stored override rather than merging" do
+      expect(stored.to_raw_hash).to eq("channels" => { "email" => false })
+      expect(stored.channels).not_to have_key("sms")
+    end
+  end
+
+  context "when values match declaration defaults" do
+    before do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: { "channels" => { "email" => false } },
+      )
+    end
+
+    subject(:result) do
+      update!.call(
+        preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      )
+    end
+
+    it "sparsifies values that match declaration defaults and deletes empty overrides" do
+      expect(result.stored_override_present).to be(false)
+      expect(
+        CommandTower::Messaging::Preferences.find_stored(
+          recipient_id: user.id,
+          notification_type_key:,
+        ),
+      ).to be_nil
+    end
+  end
+
+  context "when preference_state is empty" do
+    before do
+      CommandTower::Messaging::Preferences.upsert_stored!(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: { "channels" => { "email" => false } },
+      )
+    end
+
+    subject(:result) { update!.call(preference_state: {}) }
+
+    it "resets to defaults when preference_state is empty" do
+      expect(result.stored_override_present).to be(false)
+      expect(result.channels).to eq("email" => true, "sms" => true)
+      expect(result.inbox_enabled).to be(true)
+      expect(
+        CommandTower::Messaging::Preferences.find_stored(
+          recipient_id: user.id,
+          notification_type_key:,
+        ),
+      ).to be_nil
+    end
+  end
+
+  it "rejects unknown notification types" do
+    expect {
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key: "missing.type",
+        preference_state: { "channels" => { "email" => false } },
+      )
+    }.to raise_error(CommandTower::Messaging::Preferences::UnknownTypeError)
+  end
+
+  it "rejects settings-hidden notification types" do
+    expect {
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key: "hello_world",
+        preference_state: { "inbox" => false },
+      )
+    }.to raise_error(CommandTower::Messaging::Preferences::NotSettingsVisibleError)
+  end
+
+  it "rejects non-configurable notification types" do
+    expect {
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key: "password.changed",
+        preference_state: { "channels" => { "email" => false } },
+      )
+    }.to raise_error(CommandTower::Messaging::Preferences::InvalidPreferenceWriteError)
+  end
+
+  it "rejects unsupported inbox preferences" do
+    expect {
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key: "inbox.only",
+        preference_state: { "inbox" => true },
+      )
+    }.to raise_error(
+      CommandTower::Messaging::Preferences::InvalidPreferenceWriteError,
+      /inbox preference is not available/,
+    )
+  end
+
+  it "rejects unknown channels" do
+    expect {
+      update!.call(preference_state: { "channels" => { "push" => false } })
+    }.to raise_error(
+      CommandTower::Messaging::Preferences::InvalidPreferenceWriteError,
+      /outside allowed set/,
+    )
+  end
+
+  it "rejects non-boolean channel values" do
+    expect {
+      update!.call(preference_state: { "channels" => { "email" => "nope" } })
+    }.to raise_error(CommandTower::Messaging::Preferences::InvalidPreferenceStateError)
+  end
+
+  context "with mandatory destination disables" do
+    subject(:result) do
+      described_class.call(
+        recipient_id: user.id,
+        notification_type_key: "security.alert",
+        preference_state: { "channels" => { "email" => false }, "inbox" => false },
+        platform_enabled_channels: %w[email],
+      )
+    end
+
+    let(:evaluation) do
+      result
+      CommandTower::Messaging::Preferences.resolve(
+        notification_type_key: "security.alert",
+        recipient_id: user.id,
+        platform_enabled_channels: %w[email],
+      )
+    end
+
+    it "accepts mandatory destination disables and returns evaluator-enforced effective state" do
+      expect(result.stored_override_present).to be(true)
+      expect(result.mandatory).to be(true)
+      expect(result.channels["email"]).to be(false)
+      expect(evaluation.mandatory_enforced).to be(true)
+      expect(evaluation.permitted_channels).to include("email")
+      expect(evaluation.inbox_permitted).to be(true)
+    end
+  end
+
+  context "with repeated identical updates" do
+    let(:first) { update!.call(preference_state: { "channels" => { "email" => false } }) }
+
+    subject(:second) do
+      first
+      update!.call(preference_state: { "channels" => { "email" => false } })
+    end
+
+    it "is idempotent for repeated identical updates" do
+      expect(second.channels).to eq(first.channels)
+      expect(second.stored_override_present).to eq(first.stored_override_present)
+    end
+  end
+
+  context "when Store raises" do
+    before do
+      allow(CommandTower::Messaging::Preferences::Store).to receive(:upsert!).and_raise(
+        CommandTower::Messaging::Preferences::StoreError,
+        "db down",
+      )
+    end
+
+    it "fails closed when Store raises" do
+      expect {
+        update!.call(preference_state: { "channels" => { "email" => false } })
+      }.to raise_error(CommandTower::Messaging::Preferences::StoreError)
+    end
+  end
+
+  context "through the Preferences.update façade" do
+    subject(:result) do
+      CommandTower::Messaging::Preferences.update(
+        recipient_id: user.id,
+        notification_type_key:,
+        preference_state: { "channels" => { "email" => false } },
+        platform_enabled_channels:,
+      )
+    end
+
+    it "delegates through the Preferences.update façade" do
+      expect(result.key).to eq(notification_type_key)
+      expect(result.stored_override_present).to be(true)
+    end
+  end
+end

--- a/spec/services/command_tower/messaging/pushover/transport_spec.rb
+++ b/spec/services/command_tower/messaging/pushover/transport_spec.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+
+require "json"
+require "net/http"
+
+RSpec.describe CommandTower::Messaging::Pushover::Transport do
+  around do |example|
+    previous_adapter = CommandTower.config.messaging.pushover.adapter
+    previous_injected = described_class.instance_variable_get(:@adapter)
+    CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+    described_class.reset_adapter!
+    example.run
+  ensure
+    CommandTower.config.messaging.pushover.adapter = previous_adapter
+    described_class.instance_variable_set(:@adapter, previous_injected)
+    CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+  end
+
+  describe "fake adapter" do
+    before { CommandTower.config.messaging.pushover.adapter = "fake" }
+
+    context "when validating a user" do
+      subject(:result) do
+        described_class.validate_user!(
+          user_key: "secret-user-key",
+          application_token: "secret-app-token",
+        )
+      end
+
+      it "validates and records safe metadata without secrets" do
+        expect(result.success?).to be(true)
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.validations.last).to eq(
+          user_key_present: true, application_token_present: true,
+        )
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.validations.last.to_s).not_to include("secret-user-key")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.validations.last.to_s).not_to include("secret-app-token")
+      end
+    end
+
+    context "when FakeAdapter injects invalid_user" do
+      before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_user }
+
+      subject(:result) { described_class.validate_user!(user_key: "u", application_token: "t") }
+
+      it "returns invalid_user" do
+        expect(result.error_code).to eq(:invalid_user)
+      end
+    end
+
+    context "when FakeAdapter injects timeout on send_test_notification!" do
+      before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :timeout }
+
+      subject(:result) do
+        described_class.send_test_notification!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "returns timeout" do
+        expect(result.error_code).to eq(:timeout)
+      end
+    end
+
+    context "when FakeAdapter injects provider_unavailable" do
+      before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :provider_unavailable }
+
+      subject(:result) { described_class.validate_user!(user_key: "u", application_token: "t") }
+
+      it "returns provider_unavailable" do
+        expect(result.error_code).to eq(:provider_unavailable)
+      end
+    end
+  end
+
+  describe "log adapter" do
+    before { CommandTower.config.messaging.pushover.adapter = "log" }
+
+    context "when validate_user! logs" do
+      let(:logged) { [] }
+
+      before { allow(Rails.logger).to receive(:info) { |msg| logged << msg.to_s } }
+
+      subject(:result) do
+        described_class.validate_user!(user_key: "secret-user", application_token: "secret-token")
+      end
+
+      it "succeeds without network and logs lengths only" do
+        expect(result.success?).to be(true)
+        expect(logged.join).not_to include("secret-user")
+        expect(logged.join).not_to include("secret-token")
+        expect(logged.join).to include("messaging.pushover.log_adapter.validate_user")
+      end
+    end
+  end
+
+  describe "disabled adapter" do
+    before { CommandTower.config.messaging.pushover.adapter = "disabled" }
+
+    context "when validating a user" do
+      subject(:result) { described_class.validate_user!(user_key: "u", application_token: "t") }
+
+      it "fails closed" do
+        expect(result.success?).to be(false)
+        expect(result.error_code).to eq(:adapter_disabled)
+      end
+    end
+
+    context "when sending a production message" do
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "fails closed" do
+        expect(result.success?).to be(false)
+        expect(result.error_code).to eq(:adapter_disabled)
+      end
+    end
+  end
+
+  describe "send_message!" do
+    before { CommandTower.config.messaging.pushover.adapter = "fake" }
+
+    context "when sending a message" do
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "secret-user-key",
+          application_token: "secret-app-token",
+          title: "Hello",
+          message: "World",
+        )
+      end
+
+      it "records safe metadata and returns a provider_request_id without secrets" do
+        expect(result.success?).to be(true)
+        expect(result.provider_request_id).to be_present
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages.last[:title]).to eq("Hello")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages.last.to_s).not_to include("secret-user-key")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages.last.to_s).not_to include("secret-app-token")
+      end
+    end
+
+    context "when FakeAdapter injects invalid_credentials" do
+      before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_credentials }
+
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "returns invalid_credentials" do
+        expect(result.error_code).to eq(:invalid_credentials)
+      end
+    end
+
+    context "when FakeAdapter injects rate_limited" do
+      before { CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :rate_limited }
+
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "returns rate_limited" do
+        expect(result.error_code).to eq(:rate_limited)
+      end
+    end
+  end
+
+  describe "log adapter send_message!" do
+    before { CommandTower.config.messaging.pushover.adapter = "log" }
+
+    context "when send_message! logs" do
+      let(:logged) { [] }
+
+      before { allow(Rails.logger).to receive(:info) { |msg| logged << msg.to_s } }
+
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "secret-user", application_token: "secret-token", title: "t", message: "m",
+        )
+      end
+
+      it "succeeds with safe log metadata only" do
+        expect(result.success?).to be(true)
+        expect(logged.join).not_to include("secret-user")
+        expect(logged.join).to include("messaging.pushover.log_adapter.send_message")
+      end
+    end
+  end
+
+  describe "http adapter" do
+    before { CommandTower.config.messaging.pushover.adapter = "http" }
+
+    context "when the provider responds successfully to validate" do
+      let(:response) { instance_double(Net::HTTPOK, code: "200", body: { status: 1 }.to_json, is_a?: true) }
+
+      before do
+        allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        allow(Net::HTTP).to receive(:start).and_return(response)
+      end
+
+      subject(:result) { described_class.validate_user!(user_key: "u", application_token: "t") }
+
+      it "classifies successful validate responses" do
+        expect(result.success?).to be(true)
+      end
+    end
+
+    context "when the provider reports an invalid user" do
+      let(:response) do
+        instance_double(
+          Net::HTTPBadRequest,
+          code: "400",
+          body: { status: 0, errors: ["user key is invalid"] }.to_json,
+        )
+      end
+
+      before do
+        allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+        allow(Net::HTTP).to receive(:start).and_return(response)
+      end
+
+      subject(:result) do
+        described_class.validate_user!(user_key: "secret-user", application_token: "secret-token")
+      end
+
+      it "classifies invalid user errors without leaking secrets" do
+        expect(result.success?).to be(false)
+        expect(result.error_code).to eq(:invalid_user)
+        expect(result.error_message).not_to include("secret-user")
+        expect(result.error_message).not_to include("secret-token")
+      end
+    end
+
+    context "when the network call times out" do
+      before { allow(Net::HTTP).to receive(:start).and_raise(Net::ReadTimeout) }
+
+      subject(:result) do
+        described_class.send_test_notification!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "maps timeouts" do
+        expect(result.error_code).to eq(:timeout)
+      end
+    end
+
+    context "when send_message! succeeds and returns a request id" do
+      let(:response) do
+        instance_double(
+          Net::HTTPOK,
+          code: "200",
+          body: { status: 1, request: "req-abc-123" }.to_json,
+        )
+      end
+
+      before do
+        allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+        allow(Net::HTTP).to receive(:start).and_return(response)
+      end
+
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "u", application_token: "t", title: "Hello", message: "World",
+        )
+      end
+
+      it "captures provider request id on successful send_message!" do
+        expect(result.success?).to be(true)
+        expect(result.provider_request_id).to eq("req-abc-123")
+      end
+    end
+
+    context "when send_message! is rate limited" do
+      let(:response) do
+        instance_double(
+          Net::HTTPTooManyRequests,
+          code: "429",
+          body: { status: 0, errors: ["rate limited"] }.to_json,
+        )
+      end
+
+      before do
+        allow(response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(false)
+        allow(Net::HTTP).to receive(:start).and_return(response)
+      end
+
+      subject(:result) do
+        described_class.send_message!(
+          user_key: "u", application_token: "t", title: "t", message: "m",
+        )
+      end
+
+      it "classifies rate limits as rate_limited" do
+        expect(result.error_code).to eq(:rate_limited)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/phone_verification/readiness_transition_spec.rb
+++ b/spec/services/command_tower/services/account/phone_verification/readiness_transition_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe "phone verification readiness transition" do
+  let(:for_channel) do
+    lambda do |key, user:, platform_enabled_channels:|
+      CommandTower::Messaging::RecipientReadiness.for_channel(
+        recipient_id: user.id,
+        channel_key: key,
+        platform_enabled_channels:
+      )
+    end
+  end
+
+  let(:user) { create(:user, :without_phone) }
+  let(:platform_enabled_channels) { ["sms"] }
+
+  before do
+    CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+    CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter.reset!
+    allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+    allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(0.seconds)
+  end
+
+  it "clears identity_unverified after successful phone verification" do
+    CommandTower::Services::Account::UpdatePhone.call(user:, phone_number: "+14155552671")
+    user.reload
+
+    before = for_channel.call("sms", user:, platform_enabled_channels:)
+    expect(before.reason_codes).to include("identity_unverified")
+
+    send_result = CommandTower::Services::Account::PhoneVerification::Send.call(user:)
+    expect(send_result).to be_success
+    code = UserSecret.find_by!(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION).secret
+
+    verify_result = CommandTower::Services::Account::PhoneVerification::Verify.call(user:, code:)
+    expect(verify_result).to be_success
+    user.reload
+
+    after = for_channel.call("sms", user:, platform_enabled_channels:)
+    expect(after.reason_codes).not_to include("identity_unverified")
+    expect(after.reason_codes).not_to include("identity_missing")
+  end
+end

--- a/spec/services/command_tower/services/account/phone_verification/send_spec.rb
+++ b/spec/services/command_tower/services/account/phone_verification/send_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::PhoneVerification::Send do
+  describe ".call" do
+    subject(:result) { described_class.call(user:) }
+
+    let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: false) }
+    let(:fake_adapter) { CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter }
+
+    before do
+      CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+      fake_adapter.reset!
+      allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+      allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(30.seconds)
+    end
+
+    it "delivers an OTP without returning the code to callers" do
+      expect(result).to be_success
+      expect(result.data[:code_length]).to eq(6)
+      expect(result.data[:phone_number]).to eq("+14155552671")
+      expect(result.data[:expires_at]).to be_present
+      expect(result.data[:resend_available_at]).to be_present
+
+      delivery = fake_adapter.deliveries.last
+      expect(delivery[:to]).to eq("+14155552671")
+      expect(delivery[:body]).to match(/verification code is \d{6}/)
+    end
+
+    it "binds the issued challenge to the current phone" do
+      result
+
+      challenge = UserSecret.find_by!(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION)
+      expect(challenge.extra).to eq("+14155552671")
+      expect(challenge.secret).to match(/\A\d{6}\z/)
+    end
+
+    context "when a code was issued moments ago" do
+      before { expect(described_class.call(user:)).to be_success }
+
+      it "returns PhoneVerificationThrottledError carrying the retry time" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationThrottledError)
+        expect(result.errors.first.resend_available_at).to be_present
+      end
+    end
+
+    context "when the user has no phone" do
+      let(:user) { create(:user, :without_phone) }
+
+      it "returns PhoneMissingError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneMissingError)
+      end
+    end
+
+    context "when the phone is already verified" do
+      let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: true) }
+
+      it "returns PhoneAlreadyVerifiedError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneAlreadyVerifiedError)
+      end
+    end
+
+    context "when the SMS provider rejects the delivery" do
+      before { fake_adapter.fail_with = [:provider_unavailable, "down"] }
+
+      it "returns PhoneVerificationSendFailedError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationSendFailedError)
+      end
+    end
+
+    context "when phone verification is disabled" do
+      before do
+        allow(CommandTower.config.identity.phone_verification).to receive(:enable).and_return(false)
+      end
+
+      it "returns PhoneVerificationSendFailedError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationSendFailedError)
+      end
+
+      it "does not deliver anything" do
+        result
+
+        expect(fake_adapter.deliveries).to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/phone_verification/verify_spec.rb
+++ b/spec/services/command_tower/services/account/phone_verification/verify_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::PhoneVerification::Verify do
+  describe ".call" do
+    let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: false) }
+
+    before do
+      CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+      CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter.reset!
+      allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+      allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(0.seconds)
+    end
+
+    let(:send_code!) do
+      lambda do
+        expect(CommandTower::Services::Account::PhoneVerification::Send.call(user:)).to be_success
+
+        UserSecret.find_by!(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION).secret
+      end
+    end
+
+    context "when verification succeeds" do
+      let(:code) { send_code!.call }
+
+      subject(:result) { described_class.call(user:, code:) }
+
+      it "marks the phone validated on success" do
+        expect(result).to be_success
+        expect(result.data[:already_verified]).to eq(false)
+        expect(user.reload.phone_number_validated).to eq(true)
+      end
+
+      it "clears outstanding challenges once verified" do
+        result
+
+        expect(UserSecret.where(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION)).to be_empty
+      end
+    end
+
+    context "when already verified" do
+      before { user.update!(phone_number_validated: true) }
+
+      subject(:result) { described_class.call(user:, code: "000000") }
+
+      it "is idempotent when already verified" do
+        expect(result).to be_success
+        expect(result.data[:already_verified]).to eq(true)
+      end
+    end
+
+    context "with a wrong code" do
+      before { send_code!.call }
+
+      subject(:result) { described_class.call(user:, code: "000000") }
+
+      it "returns PhoneVerificationCodeInvalidError for a wrong code" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationCodeInvalidError)
+      end
+    end
+
+    context "when the phone is replaced after sending" do
+      let(:code) { send_code!.call }
+
+      before do
+        code
+        CommandTower::Services::Account::UpdatePhone.call(user:, phone_number: "+14155552672")
+      end
+
+      subject(:result) { described_class.call(user: user.reload, code:) }
+
+      it "returns PhoneVerificationStaleError after the phone is replaced" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationStaleError)
+        expect(user.reload.phone_number_validated).to eq(false)
+      end
+    end
+
+    context "with an expired code" do
+      let(:code) { send_code!.call }
+
+      before { UserSecret.find_by!(secret: code).update!(death_time: 1.hour.ago) }
+
+      subject(:result) { described_class.call(user:, code:) }
+
+      it "returns PhoneVerificationExpiredError for a dead code" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationExpiredError)
+      end
+    end
+
+    context "when the user has no phone" do
+      let(:user_without_phone) { create(:user, :without_phone) }
+
+      subject(:result) { described_class.call(user: user_without_phone, code: "000000") }
+
+      it "returns PhoneMissingError when the user has no phone" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneMissingError)
+      end
+    end
+
+    context "when a code is resent for a replacement phone" do
+      before do
+        send_code!.call
+        CommandTower::Services::Account::UpdatePhone.call(user:, phone_number: "+14155552672")
+        user.reload
+      end
+
+      let(:new_code) { send_code!.call }
+
+      before { new_code }
+
+      it "binds a resent code to the replacement phone" do
+        expect(UserSecret.find_by!(user:, reason: CommandTower::Secrets::PHONE_VERIFICATION).extra)
+          .to eq("+14155552672")
+        expect(described_class.call(user:, code: new_code)).to be_success
+        expect(user.reload.phone_number_validated).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/pushover/create_spec.rb
+++ b/spec/services/command_tower/services/account/pushover/create_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::Pushover::Create do
+  describe ".call" do
+    subject(:result) { described_class.call(user:, user_key:, application_token:) }
+
+    let(:user) { create(:user) }
+    let(:user_key) { "pushover-user-key-abcd" }
+    let(:application_token) { "pushover-app-token-zzzz" }
+
+    context "when credentials are valid" do
+      it { expect(result).to be_success }
+
+      it "creates a pushover endpoint safe view" do
+        expect(result.data[:safe_view]).to be_present
+        expect(result.data[:safe_view].channel_key).to eq("pushover")
+        expect(result.data[:safe_view].lifecycle_state).to eq("active")
+        expect(result.data[:safe_view].verification_state).to eq("unverified")
+        expect(result.data[:safe_view].credentials_configured).to be(true)
+      end
+    end
+
+    context "when pushover is already configured with different credentials" do
+      before do
+        described_class.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      let(:user_key) { "pushover-user-key-efgh" }
+      let(:application_token) { "pushover-app-token-yyyy" }
+
+      it "returns PushoverAlreadyConfiguredError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverAlreadyConfiguredError)
+      end
+    end
+
+    context "when user_key is blank" do
+      let(:user_key) { "" }
+
+      it "returns a validation error" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::ValidationError)
+      end
+    end
+
+    context "when application_token is blank" do
+      let(:application_token) { "" }
+
+      it "returns a validation error" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::ValidationError)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/pushover/destroy_spec.rb
+++ b/spec/services/command_tower/services/account/pushover/destroy_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::Pushover::Destroy do
+  describe ".call" do
+    subject(:result) { described_class.call(user:) }
+
+    let(:user) { create(:user) }
+
+    context "when pushover is not configured" do
+      it "returns PushoverNotConfiguredError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverNotConfiguredError)
+      end
+    end
+
+    context "when pushover is configured" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns a revoked safe view" do
+        expect(result.data[:safe_view].lifecycle_state).to eq("revoked")
+        expect(result.data[:safe_view].revoked_at).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/pushover/replace_spec.rb
+++ b/spec/services/command_tower/services/account/pushover/replace_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::Pushover::Replace do
+  describe ".call" do
+    subject(:result) { described_class.call(user:, user_key:, application_token:) }
+
+    let(:user) { create(:user) }
+    let(:user_key) { "pushover-user-key-efgh" }
+    let(:application_token) { "pushover-app-token-yyyy" }
+
+    context "when replacing existing credentials" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns a new unverified endpoint with updated masked display" do
+        expect(result.data[:safe_view].verification_state).to eq("unverified")
+        expect(result.data[:safe_view].lifecycle_state).to eq("active")
+        expect(result.data[:safe_view].masked_display_value).to eq("#{"•" * 8}efgh")
+        expect(result.data[:safe_view].credentials_configured).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/pushover/show_spec.rb
+++ b/spec/services/command_tower/services/account/pushover/show_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::Pushover::Show do
+  describe ".call" do
+    subject(:result) { described_class.call(user:) }
+
+    let(:user) { create(:user) }
+
+    context "when no pushover endpoint exists" do
+      it { expect(result).to be_success }
+
+      it "returns a nil safe view" do
+        expect(result.data[:safe_view]).to be_nil
+      end
+    end
+
+    context "when pushover is configured" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns the active endpoint safe view" do
+        expect(result.data[:safe_view]).to be_present
+        expect(result.data[:safe_view].channel_key).to eq("pushover")
+        expect(result.data[:safe_view].lifecycle_state).to eq("active")
+        expect(result.data[:safe_view].credentials_configured).to be(true)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/account/pushover/verify_spec.rb
+++ b/spec/services/command_tower/services/account/pushover/verify_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Account::Pushover::Verify do
+  describe ".call" do
+    subject(:result) { described_class.call(user:) }
+
+    let(:user) { create(:user) }
+
+    around do |example|
+      previous = CommandTower.config.messaging.pushover.adapter
+      CommandTower.config.messaging.pushover.adapter = "fake"
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      example.run
+    ensure
+      CommandTower.config.messaging.pushover.adapter = previous
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+    end
+
+    context "when pushover is not configured" do
+      it "returns PushoverNotConfiguredError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverNotConfiguredError)
+      end
+    end
+
+    context "when pushover is configured" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns a verified safe view" do
+        expect(result.data[:safe_view].verification_state).to eq("verified")
+        expect(result.data[:safe_view].verified_at).to be_present
+      end
+    end
+
+    context "when Pushover rejects the user key" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_user
+      end
+
+      it "returns PushoverVerificationFailedError" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverVerificationFailedError)
+        expect(result.errors.first.code).to eq("pushover_invalid_user")
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/me/capabilities_spec.rb
+++ b/spec/services/command_tower/services/me/capabilities_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Me::Capabilities do
+  describe ".project" do
+    subject(:project) { described_class.project(user) }
+
+    let(:user) { create(:user, email_validated: true) }
+
+    before do
+      allow(CommandTower::Messaging::ChannelDetectors)
+        .to receive(:sms_product_ready?).and_return(false)
+      allow(CommandTower::Messaging::ChannelDetectors)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    it "returns the self-service capability flags" do
+      expect(project).to eq(
+        editName: { enabled: true },
+        editUsername: { enabled: false },
+        changeEmail: { enabled: false },
+        changePassword: { enabled: true },
+        editPhone: { enabled: false },
+        editPushover: { enabled: false },
+        logoutAllDevices: { enabled: false },
+        verifyEmail: { enabled: false }
+      )
+    end
+
+    context "when SMS product is ready" do
+      before do
+        allow(CommandTower::Messaging::ChannelDetectors)
+          .to receive(:sms_product_ready?).and_return(true)
+      end
+
+      it "enables editPhone" do
+        expect(project[:editPhone]).to eq(enabled: true)
+      end
+    end
+
+    context "when Pushover is configured" do
+      before do
+        allow(CommandTower::Messaging::ChannelDetectors)
+          .to receive(:pushover_configured?).and_return(true)
+      end
+
+      it "enables editPushover" do
+        expect(project[:editPushover]).to eq(enabled: true)
+      end
+    end
+
+    context "when the email is unverified" do
+      let(:user) { create(:user, :unvalidated_email) }
+
+      it "enables verifyEmail" do
+        expect(project[:verifyEmail]).to eq(enabled: true)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/me/change_password_spec.rb
+++ b/spec/services/command_tower/services/me/change_password_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Me::ChangePassword do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        user:,
+        current_password:,
+        password:,
+        password_confirmation:
+      )
+    end
+
+    let(:stored_password) { "password1234abcdef" }
+    let(:user) { create(:user, password: stored_password, password_confirmation: stored_password) }
+    let(:current_password) { stored_password }
+    let(:password) { "newpassword5678ghij" }
+    let(:password_confirmation) { password }
+
+    it "changes the password" do
+      expect(result).to be_success
+      expect(user.reload.authenticate(password)).to be_truthy
+    end
+
+    context "with an incorrect current password" do
+      let(:current_password) { "wrong-password-xyz" }
+
+      it "fails with a camelCase field error" do
+        expect(result).to be_failure
+        expect(result.errors.first).to be_a(CommandTower::Errors::ValidationError)
+        expect(result.errors.first.details).to have_key(:currentPassword)
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/me/pushover_product_gate_spec.rb
+++ b/spec/services/command_tower/services/me/pushover_product_gate_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Me::PushoverProductGate do
+  describe ".enabled?" do
+    subject(:enabled) { described_class.enabled? }
+
+    before do
+      allow(CommandTower::Messaging::ChannelDetectors)
+        .to receive(:pushover_configured?).and_return(configured)
+    end
+
+    context "when Pushover is configured" do
+      let(:configured) { true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when Pushover is not configured" do
+      let(:configured) { false }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/services/command_tower/services/me/sms_product_gate_spec.rb
+++ b/spec/services/command_tower/services/me/sms_product_gate_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Me::SmsProductGate do
+  describe ".enabled?" do
+    subject(:enabled) { described_class.enabled? }
+
+    before do
+      allow(CommandTower::Messaging::ChannelDetectors)
+        .to receive(:sms_product_ready?).and_return(ready)
+    end
+
+    context "when SMS product dual-gate is ready" do
+      let(:ready) { true }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when SMS product dual-gate is not ready" do
+      let(:ready) { false }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/services/command_tower/services/me/update_name_spec.rb
+++ b/spec/services/command_tower/services/me/update_name_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Me::UpdateName do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(user:, first_name:, last_name:)
+    end
+
+    let(:user) { create(:user, first_name: "Old", last_name: "Name") }
+    let(:first_name) { "New" }
+    let(:last_name) { "Person" }
+
+    it "updates both name fields" do
+      expect(result).to be_success
+      expect(user.reload).to have_attributes(first_name: "New", last_name: "Person")
+    end
+
+    context "when names are unchanged" do
+      let(:first_name) { "Old" }
+      let(:last_name) { "Name" }
+
+      it "succeeds without modifying the user" do
+        expect { result }.not_to(change { user.reload.updated_at })
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/communications/produce_many_spec.rb
+++ b/spec/services/command_tower/services/messaging/communications/produce_many_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Communications::ProduceMany, :messaging_accept do
+  let(:users) { create_list(:user, 2) }
+  let(:user_ids) { users.map(&:id) }
+  let(:notification_type_key) { "promo.test" }
+  let(:campaign_identity) { "campaign/test-1" }
+  let(:title) { "Hello" }
+  let(:body) { "Book here: https://example.com/deeplink/1" }
+  let(:platform_enabled_channels) { [] }
+  let(:execution_mode) { :sync }
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: true,
+        mandatory: false,
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      ),
+    )
+  end
+
+  let(:call_service) do
+    lambda do |**overrides|
+      described_class.call(
+        user_ids:,
+        notification_type_key:,
+        campaign_identity:,
+        title:,
+        body:,
+        platform_enabled_channels:,
+        execution_mode:,
+        **overrides
+      )
+    end
+  end
+
+  context "with an empty audience" do
+    subject(:result) { call_service.call(user_ids: []) }
+
+    it "accepts an empty audience" do
+      expect(result).to be_success
+      expect(result.data).to include(mode: :sync, requested: 0, accepted: 0, failed: 0, skipped: 0)
+    end
+  end
+
+  context "in sync mode with two users" do
+    subject(:result) { call_service.call }
+
+    it "produces one communication per user id in sync mode" do
+      expect(result).to be_success
+      expect(result.data).to include(requested: 2, accepted: 2, failed: 0, skipped: 0, mode: :sync)
+      users.each do |user|
+        expect(
+          CommandTower::Messaging::Communication.find_by(
+            user_id: user.id,
+            host_event_identity: "#{campaign_identity}/#{user.id}",
+          )
+        ).to be_present
+      end
+    end
+  end
+
+  context "when some user ids are missing" do
+    subject(:result) { call_service.call(user_ids: [users.first.id, 9_999_999_999]) }
+
+    it "skips missing user ids" do
+      expect(result).to be_success
+      expect(result.data).to include(accepted: 1, skipped: 1, failed: 0)
+    end
+  end
+
+  context "when sync mode exceeds the cap" do
+    let(:ids) { (1..26).to_a }
+
+    subject(:result) { call_service.call(user_ids: ids, execution_mode: :sync) }
+
+    it "rejects sync mode above the cap" do
+      expect(result).to be_failure
+      expect(result.errors.first).to be_a(CommandTower::Errors::ValidationError)
+    end
+  end
+
+  context "in async mode" do
+    subject(:result) { call_service.call(execution_mode: :async) }
+
+    it "enqueues recipient jobs in async mode without claiming Produce completion" do
+      expect(result).to be_success
+      expect(result.data).to include(
+        mode: :async,
+        requested: 2,
+        enqueued: 2,
+        enqueue_failed: 0,
+        campaign_identity:,
+      )
+      expect(result.data).not_to have_key(:accepted)
+      expect(CommandTower::Messaging::Communications::ProduceRecipientJob).to have_been_enqueued.exactly(2).times
+    end
+  end
+
+  context "when one Produce call fails" do
+    before do
+      allow(CommandTower::Services::Messaging::Communications::Produce).to receive(:call).and_wrap_original do |method, **kwargs|
+        if kwargs[:user].id == users.last.id
+          CommandTower::Services::ServiceResult.failure(errors: [CommandTower::Errors::InternalError.new])
+        else
+          method.call(**kwargs)
+        end
+      end
+    end
+
+    subject(:result) { call_service.call }
+
+    it "isolates individual Produce failures" do
+      expect(result).to be_success
+      expect(result.data).to include(accepted: 1, failed: 1, skipped: 0)
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/communications/produce_spec.rb
+++ b/spec/services/command_tower/services/messaging/communications/produce_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Communications::Produce, :messaging_accept do
+  describe ".call" do
+    let(:user) { create(:user, email: "produce-user@example.com", username: "produceuser") }
+    let(:notification_type_key) { "booking.success" }
+    let(:platform_enabled_channels) { [] }
+    let(:host_event_identity) { "booking.success/#{user.id}/fixed-identity" }
+    let(:title) { "Booking confirmed" }
+    let(:body) { "Your booking was confirmed." }
+    let(:metadata) { nil }
+    let(:call_kwargs) do
+      {
+        user:,
+        notification_type_key:,
+        host_event_identity:,
+        title:,
+        body:,
+        metadata:,
+        platform_enabled_channels:,
+      }
+    end
+
+    before do
+      register_and_seal_notification_types(
+        build_notification_type_declaration(
+          key: notification_type_key,
+          allowed_channels: %w[email sms],
+          default_channels: %w[email],
+          inbox_available: true,
+          user_configurable: true,
+          mandatory: false,
+          default_preference_state: {
+            "channels" => { "email" => true, "sms" => true },
+            "inbox" => true,
+          },
+        ),
+      )
+    end
+
+    context "with a persisted user and registered type" do
+      subject(:result) { described_class.call(**call_kwargs) }
+
+      it "returns a successful ServiceResult" do
+        expect(result).to be_success
+      end
+
+      it "exposes Accept result fields on data" do
+        expect(result.data).to include(
+          recipient_id: user.id,
+          notification_type_key:,
+          host_event_identity:,
+          communication_status: "accepted",
+          idempotent_replay: false,
+          selected_channels: [],
+          inbox_selected: true,
+        )
+        expect(result.data[:communication_id]).to be_present
+        expect(result.data[:destination_plan_id]).to be_present
+        expect(result.data[:inbox_item_id]).to be_present
+      end
+
+      it "persists an inbox-only aggregate when no channels are enabled" do
+        result
+
+        communication = CommandTower::Messaging::Communication.find(result.data[:communication_id])
+        expect(communication.user_id).to eq(user.id)
+        expect(communication.notification_type_key).to eq(notification_type_key)
+        expect(communication.status).to eq("accepted")
+        expect(communication.destination_plan).to be_present
+        expect(communication.inbox_item).to be_present
+        expect(communication.channel_deliveries).to be_empty
+        expect(CommandTower::Messaging::DeliveryAttempt.count).to eq(0)
+      end
+
+      it "enqueues HandoffJob after commit" do
+        result
+
+        expect(CommandTower::Messaging::HandoffJob).to have_been_enqueued.with(result.data[:communication_id])
+      end
+    end
+
+    context "when passing host platform_enabled_channels" do
+      subject(:result) { described_class.call(**call_kwargs) }
+
+      let(:platform_enabled_channels) { %w[email] }
+
+      before do
+        allow(CommandTower::Messaging).to receive(:accept).and_call_original
+      end
+
+      it "forwards the supplied channels to Accept" do
+        result
+
+        expect(CommandTower::Messaging).to have_received(:accept).with(
+          hash_including(
+            recipient_id: user.id,
+            notification_type_key:,
+            platform_enabled_channels: %w[email],
+            preference_state: nil,
+            message_overrides: nil,
+          )
+        )
+      end
+    end
+
+    context "when Accept is replayed with the same identity and content" do
+      subject(:second_result) { described_class.call(**call_kwargs) }
+
+      let!(:first_result) { described_class.call(**call_kwargs) }
+
+      before do
+        clear_enqueued_jobs
+      end
+
+      it "returns idempotent_replay without duplicating rows or re-enqueueing handoff" do
+        expect(second_result).to be_success
+        expect(second_result.data[:idempotent_replay]).to be(true)
+        expect(second_result.data[:communication_id]).to eq(first_result.data[:communication_id])
+        expect(CommandTower::Messaging::Communication.count).to eq(1)
+        expect(CommandTower::Messaging::DestinationPlan.count).to eq(1)
+        expect(CommandTower::Messaging::InboxItem.count).to eq(1)
+        expect(CommandTower::Messaging::HandoffJob).not_to have_been_enqueued
+      end
+    end
+
+    context "when the user cannot be resolved" do
+      subject(:result) { described_class.call(**call_kwargs) }
+
+      let(:user) { build(:user, email: "unsaved-produce@example.com", username: "unsavedproduce") }
+
+      it "propagates RecipientUnresolvedError" do
+        expect(result).to be_failure
+        expect(result.errors).to contain_exactly(
+          an_instance_of(CommandTower::Errors::Messaging::RecipientUnresolvedError)
+        )
+      end
+    end
+
+    context "when user is nil" do
+      subject(:result) do
+        described_class.call(
+          user: nil,
+          notification_type_key:,
+          host_event_identity: "booking.success/missing",
+          title:,
+          body:,
+          platform_enabled_channels:,
+        )
+      end
+
+      it "returns ValidationError" do
+        expect(result).to be_failure
+        expect(result.errors).to contain_exactly(an_instance_of(CommandTower::Errors::ValidationError))
+      end
+    end
+
+    context "when platform_enabled_channels is omitted" do
+      subject(:result) do
+        described_class.call(
+          user:,
+          notification_type_key:,
+          host_event_identity:,
+          title:,
+          body:,
+        )
+      end
+
+      it "returns ValidationError" do
+        expect(result).to be_failure
+        expect(result.errors).to contain_exactly(an_instance_of(CommandTower::Errors::ValidationError))
+      end
+    end
+
+    shared_examples "maps Accept exception to application error" do |accept_error_class, application_error_class|
+      subject(:result) { described_class.call(**call_kwargs) }
+
+      before do
+        allow(CommandTower::Messaging).to receive(:accept).and_raise(accept_error_class, "mapped")
+      end
+
+      it "returns #{application_error_class}" do
+        expect(result).to be_failure
+        expect(result.errors).to contain_exactly(an_instance_of(application_error_class))
+        expect(result.errors.first.retryable?).to be(false)
+      end
+    end
+
+    context "when Accept raises ValidationError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::ValidationError,
+                       CommandTower::Errors::ValidationError
+    end
+
+    context "when Accept raises UnknownTypeError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::UnknownTypeError,
+                       CommandTower::Errors::Messaging::AcceptRejectedError
+    end
+
+    context "when Accept raises InvalidPreferenceError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::InvalidPreferenceError,
+                       CommandTower::Errors::Messaging::AcceptRejectedError
+    end
+
+    context "when Accept raises IllegalOverrideError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::IllegalOverrideError,
+                       CommandTower::Errors::Messaging::AcceptRejectedError
+    end
+
+    context "when Accept raises ImpossibleMandatoryPlanError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::ImpossibleMandatoryPlanError,
+                       CommandTower::Errors::Messaging::AcceptRejectedError
+    end
+
+    context "when Accept raises IdempotencyConflictError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::IdempotencyConflictError,
+                       CommandTower::Errors::Messaging::IdempotencyConflictError
+    end
+
+    context "when Accept raises PersistenceError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::PersistenceError,
+                       CommandTower::Errors::InternalError
+    end
+
+    context "when Accept raises InvariantError" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::InvariantError,
+                       CommandTower::Errors::InternalError
+    end
+
+    context "when Accept raises a generic Accept::Error" do
+      include_examples "maps Accept exception to application error",
+                       CommandTower::Messaging::Accept::Error,
+                       CommandTower::Errors::InternalError
+    end
+
+    context "when metadata and title/body are supplied" do
+      subject(:result) { described_class.call(**call_kwargs) }
+
+      let(:metadata) { { "deep_link" => "/bookings/1" } }
+      let(:title) { "Custom title" }
+      let(:body) { "Custom body" }
+
+      before do
+        allow(CommandTower::Messaging).to receive(:accept).and_call_original
+      end
+
+      it "passes metadata, title, and body through to Accept" do
+        result
+
+        expect(CommandTower::Messaging).to have_received(:accept).with(
+          hash_including(
+            title: "Custom title",
+            body: "Custom body",
+            metadata: { "deep_link" => "/bookings/1" },
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/inbox/core_spec.rb
+++ b/spec/services/command_tower/services/messaging/inbox/core_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "Messaging inbox services", :messaging_inbox do
+  let(:user) { create(:user) }
+
+  context "when listing inbox items" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) { CommandTower::Services::Messaging::Inbox::List.call(user:, limit: 50, offset: 0, scope: "inbox") }
+
+    it "lists inbox items" do
+      expect(result).to be_success
+      expect(result.data[:items].map { |entry| entry[:id] }).to include(item.id)
+    end
+  end
+
+  context "when opening an inbox item" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) { CommandTower::Services::Messaging::Inbox::Open.call(user:, inbox_item_id: item.id) }
+
+    it "opens an inbox item" do
+      expect(result).to be_success
+      expect(result.data[:item][:viewed_at]).to be_present
+    end
+  end
+
+  context "when bulk marking inbox items read" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) { CommandTower::Services::Messaging::Inbox::BulkRead.call(user:, inbox_item_ids: [item.id]) }
+
+    it "bulk marks inbox items read" do
+      expect(result).to be_success
+      expect(result.data[:bulk_result]).to include(ids: [item.id], changed_count: 1)
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/preferences/platform_enabled_channels_spec.rb
+++ b/spec/services/command_tower/services/messaging/preferences/platform_enabled_channels_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Preferences::PlatformEnabledChannels do
+  after do
+    CommandTower.config.messaging.platform_enabled_channels = -> { [] }
+  end
+
+  context "when unset" do
+    before { CommandTower.config.messaging.platform_enabled_channels = -> { [] } }
+
+    it "defaults to an empty list when unset" do
+      expect(described_class.call).to eq([])
+    end
+  end
+
+  context "with a configured host callable" do
+    before { CommandTower.config.messaging.platform_enabled_channels = -> { %w[email sms] } }
+
+    it "invokes the configured host callable" do
+      expect(described_class.call).to eq(%w[email sms])
+    end
+  end
+
+  context "when inspecting source" do
+    let(:source) do
+      File.read(
+        CommandTower::Engine.root.join(
+          "app/services/command_tower/services/messaging/preferences/platform_enabled_channels.rb"
+        )
+      )
+    end
+
+    it "does not reference host product constants" do
+      expect(source).not_to include("Services::Messaging::PlatformEnabledChannels")
+      expect(source).not_to include("doublefloor")
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/preferences/show_spec.rb
+++ b/spec/services/command_tower/services/messaging/preferences/show_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Preferences::Show, :messaging_preferences do
+  let(:user) { create(:user) }
+
+  before do
+    CommandTower.config.messaging.platform_enabled_channels = -> { %w[email] }
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: "booking_confirmation",
+        label: "Booking Confirmation",
+        category_key: "reservations",
+        category_label: "Reservations",
+        category_order: 10,
+        type_order: 10,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        settings_visible: true,
+      ),
+    )
+  end
+
+  after do
+    CommandTower.config.messaging.platform_enabled_channels = -> { [] }
+  end
+
+  context "with the host-injected platform channels" do
+    subject(:result) { described_class.call(user:) }
+
+    it "returns a catalog for the recipient" do
+      expect(result).to be_success
+      expect(result.data[:catalog].categories.map(&:key)).to eq(%w[reservations])
+    end
+  end
+
+  context "when platform channels are empty" do
+    before { CommandTower.config.messaging.platform_enabled_channels = -> { [] } }
+
+    subject(:result) { described_class.call(user:) }
+
+    let(:booking) { result.data[:catalog].categories.first.notifications.first }
+
+    it "uses the host-injected platform_enabled_channels callable" do
+      expect(result).to be_success
+      expect(booking.available_channels).to eq([])
+    end
+  end
+end

--- a/spec/services/command_tower/services/messaging/preferences/update_spec.rb
+++ b/spec/services/command_tower/services/messaging/preferences/update_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Preferences::Update, :messaging_preferences do
+  let(:user) { create(:user) }
+
+  before do
+    CommandTower.config.messaging.platform_enabled_channels = -> { %w[email] }
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: "booking_confirmation",
+        label: "Booking Confirmation",
+        category_key: "reservations",
+        category_label: "Reservations",
+        category_order: 10,
+        type_order: 10,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        settings_visible: true,
+        user_configurable: true,
+      ),
+      build_notification_type_declaration(
+        key: "hello_world",
+        label: "Hello World",
+        category_key: "development",
+        category_label: "Development",
+        category_order: 1000,
+        type_order: 10,
+        allowed_channels: [],
+        default_channels: [],
+        default_preference_state: { "channels" => {}, "inbox" => true },
+        settings_visible: false,
+        user_configurable: false,
+      ),
+    )
+  end
+
+  after do
+    CommandTower.config.messaging.platform_enabled_channels = -> { [] }
+  end
+
+  context "when persisting a preference update" do
+    subject(:result) do
+      described_class.call(
+        user:,
+        notification_type_key: "booking_confirmation",
+        preference_state: { "inbox" => false, "channels" => { "email" => false } },
+      )
+    end
+
+    it "succeeds" do
+      expect(result).to be_success
+    end
+
+    it "stores the preference change" do
+      expect(result.data[:notification].inbox_enabled).to eq(false)
+    end
+  end
+
+  context "with an unknown notification type" do
+    subject(:result) do
+      described_class.call(
+        user:,
+        notification_type_key: "missing",
+        preference_state: {},
+      )
+    end
+
+    it { expect(result).to be_failure }
+    it { expect(result.errors.first).to be_a(CommandTower::Errors::NotFoundError) }
+  end
+
+  context "with a settings-hidden notification type" do
+    subject(:result) do
+      described_class.call(
+        user:,
+        notification_type_key: "hello_world",
+        preference_state: {},
+      )
+    end
+
+    it { expect(result).to be_failure }
+    it { expect(result.errors.first).to be_a(CommandTower::Errors::NotFoundError) }
+  end
+end

--- a/spec/services/command_tower/services/messaging/recipients_spec.rb
+++ b/spec/services/command_tower/services/messaging/recipients_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Services::Messaging::Recipients do
+  describe ".call" do
+    context "with a persisted user" do
+      let(:user) { create(:user) }
+
+      subject(:result) { described_class.call(user:) }
+
+      it "resolves a persisted user id" do
+        expect(result).to be_success
+        expect(result.data[:recipient_id]).to eq(user.id)
+      end
+    end
+
+    context "with an unpersisted user" do
+      subject(:result) { described_class.call(user: build(:user)) }
+
+      it "fails for an unpersisted user" do
+        expect(result).not_to be_success
+        expect(result.errors.first).to be_a(CommandTower::Errors::Messaging::RecipientUnresolvedError)
+      end
+    end
+  end
+end

--- a/spec/support/messaging_preferences.rb
+++ b/spec/support/messaging_preferences.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module MessagingPreferencesHelper
+  module_function
+
+  def build_preference_state(channels: {}, inbox: nil)
+    state = { "channels" => channels }
+    state["inbox"] = inbox unless inbox.nil?
+    state
+  end
+
+  def upsert_notification_preference!(recipient_id:, notification_type_key:, preference_state:)
+    CommandTower::Messaging::Preferences.upsert_stored!(
+      recipient_id:,
+      notification_type_key:,
+      preference_state:,
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include MessagingPreferencesHelper, :messaging_preferences
+  config.include MessagingNotificationTypesHelper, :messaging_preferences
+
+  config.around(:each, :messaging_preferences) do |example|
+    MessagingNotificationTypesHelper.reset_notification_type_registry!
+    example.run
+    MessagingNotificationTypesHelper.reset_notification_type_registry!
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/change_password_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/change_password_workflow_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::ChangePasswordWorkflow do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        current_user: user,
+        current_password: current_password,
+        password: password,
+        password_confirmation: password_confirmation
+      )
+    end
+
+    let(:user) { create(:user) }
+    let(:current_password) { "current-password" }
+    let(:password) { "new-password1234" }
+    let(:password_confirmation) { password }
+
+    context "when the password change succeeds" do
+      before do
+        allow(CommandTower::Services::Me::ChangePassword).to receive(:call).and_return(
+          CommandTower::Services::ServiceResult.success
+        )
+      end
+
+      it "returns the change password payload with clear token effect" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:message]).to eq("Password updated successfully.")
+        expect(result.response_effects[:clear_token]).to eq(true)
+      end
+    end
+
+    context "when the password change fails validation" do
+      let(:validation_error) do
+        CommandTower::Errors::ValidationError.new(details: { currentPassword: "Incorrect current password" })
+      end
+
+      before do
+        allow(CommandTower::Services::Me::ChangePassword).to receive(:call).and_return(
+          CommandTower::Services::ServiceResult.failure(errors: [validation_error])
+        )
+      end
+
+      it "returns unprocessable_entity" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to eq(validation_error)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/clear_phone_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/clear_phone_workflow_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::ClearPhoneWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: true, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+      allow(CommandTower::Messaging::Execution::Adapters::Sms::Configuration)
+        .to receive(:sms_configured?).and_return(false)
+      allow(CommandTower::Identity::PhoneVerification::SmsConfiguration)
+        .to receive(:sms_ready?).and_return(false)
+      allow(CommandTower::Messaging::Execution::Adapters::Pushover::Configuration)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    context "when clearing the phone succeeds" do
+      it "returns the account payload with the phone cleared" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:id]).to eq(user.id)
+        expect(result.payload[:phoneNumber]).to be_nil
+        expect(user.reload.phone_number).to be_nil
+        expect(result.response_effects[:set_expire_header]).to eq(auth_context.token_expires_at)
+      end
+    end
+
+    context "when the SMS product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns service_unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::SmsCapabilityUnavailableError)
+      end
+    end
+
+    context "when clearing the phone fails" do
+      let(:internal_error) { CommandTower::Errors::InternalError.new }
+
+      before do
+        allow(CommandTower::Services::Account::ClearPhone).to receive(:call).and_return(
+          CommandTower::Services::ServiceResult.failure(errors: [internal_error])
+        )
+      end
+
+      it "returns internal_server_error" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:internal_server_error)
+        expect(result.errors.first).to eq(internal_error)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/error_mapping_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/error_mapping_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::ErrorMapping do
+  describe ".http_status_for" do
+    {
+      CommandTower::Errors::Account::PhoneMissingError => :unprocessable_entity,
+      CommandTower::Errors::Account::PhoneAlreadyVerifiedError => :unprocessable_entity,
+      CommandTower::Errors::Account::PhoneVerificationCodeInvalidError => :unprocessable_entity,
+      CommandTower::Errors::Account::PhoneVerificationExpiredError => :unprocessable_entity,
+      CommandTower::Errors::Account::PhoneVerificationStaleError => :unprocessable_entity,
+      CommandTower::Errors::Account::PhoneVerificationThrottledError => :too_many_requests,
+      CommandTower::Errors::Account::SmsCapabilityUnavailableError => :service_unavailable,
+      CommandTower::Errors::Account::PhoneVerificationSendFailedError => :bad_gateway,
+      CommandTower::Errors::Account::PushoverCapabilityUnavailableError => :service_unavailable,
+      CommandTower::Errors::Account::PushoverNotConfiguredError => :unprocessable_entity,
+      CommandTower::Errors::Account::PushoverAlreadyConfiguredError => :unprocessable_entity,
+      CommandTower::Errors::Account::PushoverProviderUnavailableError => :bad_gateway,
+    }.each do |error_class, status|
+      it "maps #{error_class.name} to #{status}" do
+        expect(described_class.http_status_for(error_class.new)).to eq(status)
+      end
+    end
+
+    it "maps PushoverVerificationFailedError to unprocessable_entity" do
+      expect(
+        described_class.http_status_for(
+          CommandTower::Errors::Account::PushoverVerificationFailedError.new(code: "pushover_invalid_user")
+        )
+      ).to eq(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/phone_verification/send_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/phone_verification/send_workflow_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::PhoneVerification::SendWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: false, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+    let(:fake_adapter) { CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter }
+
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+      CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+      fake_adapter.reset!
+      allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+      allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(0.seconds)
+    end
+
+    context "when sending a verification code succeeds" do
+      it "returns verification metadata without leaking the OTP" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:codeLength]).to eq(6)
+        expect(result.payload[:phoneNumber]).to eq("+14155552671")
+        expect(result.payload[:expiresAt]).to be_present
+        expect(result.payload[:resendAvailableAt]).to be_present
+        expect(result.payload.values.join).not_to match(/\b\d{6}\b/)
+        expect(result.response_effects[:set_expire_header]).to eq(auth_context.token_expires_at)
+      end
+    end
+
+    context "when the SMS product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns service_unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::SmsCapabilityUnavailableError)
+      end
+    end
+
+    context "when resend is throttled" do
+      before do
+        allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(30.seconds)
+        expect(CommandTower::Services::Account::PhoneVerification::Send.call(user:)).to be_success
+      end
+
+      it "returns too_many_requests with resend metadata" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:too_many_requests)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationThrottledError)
+        expect(result.meta[:resendAvailableAt]).to be_present
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/phone_verification/verify_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/phone_verification/verify_workflow_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::PhoneVerification::VerifyWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, code: code, auth_context: auth_context) }
+
+    let(:user) { create(:user, phone_number: "+14155552671", phone_number_validated: false, roles: ["member"]) }
+    let(:code) { "000000" }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+    let(:fake_adapter) { CommandTower::Identity::PhoneVerification::SmsTransport::Adapters::FakeAdapter }
+
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+      CommandTower::Identity::PhoneVerification::SmsTransport.reset_adapter!
+      fake_adapter.reset!
+      allow(CommandTower.config.identity.phone_verification).to receive(:sms_adapter).and_return("fake")
+      allow(CommandTower.config.identity.phone_verification).to receive(:resend_cooldown).and_return(0.seconds)
+      allow(CommandTower::Messaging::Execution::Adapters::Sms::Configuration)
+        .to receive(:sms_configured?).and_return(false)
+      allow(CommandTower::Identity::PhoneVerification::SmsConfiguration)
+        .to receive(:sms_ready?).and_return(false)
+      allow(CommandTower::Messaging::Execution::Adapters::Pushover::Configuration)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    context "when verifying a valid code succeeds" do
+      let(:code) do
+        expect(CommandTower::Services::Account::PhoneVerification::Send.call(user:)).to be_success
+        fake_adapter.deliveries.last[:body][/\d{6}/]
+      end
+
+      before { code }
+
+      it "returns the account payload with the phone validated" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:id]).to eq(user.id)
+        expect(result.payload[:phoneNumberValidated]).to eq(true)
+        expect(user.reload.phone_number_validated).to eq(true)
+        expect(result.response_effects[:set_expire_header]).to eq(auth_context.token_expires_at)
+      end
+    end
+
+    context "when the SMS product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns service_unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::SmsCapabilityUnavailableError)
+      end
+    end
+
+    context "when the verification code is invalid" do
+      before do
+        expect(CommandTower::Services::Account::PhoneVerification::Send.call(user:)).to be_success
+      end
+
+      it "returns unprocessable_entity" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PhoneVerificationCodeInvalidError)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/pushover/create_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/pushover/create_workflow_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::Pushover::CreateWorkflow do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        current_user: user,
+        user_key:,
+        application_token:,
+        auth_context: auth_context
+      )
+    end
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:user_key) { "pushover-user-key-abcd" }
+    let(:application_token) { "pushover-app-token-zzzz" }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+    end
+
+    context "when Pushover product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns capability unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverCapabilityUnavailableError)
+        expect(result.errors.first.code).to eq("pushover_capability_unavailable")
+      end
+    end
+
+    context "when creating credentials succeeds" do
+      around do |example|
+        previous = CommandTower.config.messaging.pushover.adapter
+        CommandTower.config.messaging.pushover.adapter = "fake"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+        example.run
+      ensure
+        CommandTower.config.messaging.pushover.adapter = previous
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns configured payload without secrets" do
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:configured]).to eq(true)
+        expect(result.payload[:channelKey]).to eq("pushover")
+        expect(result.payload[:verificationState]).to eq("unverified")
+        expect(result.payload.to_json).not_to include("pushover-user-key-abcd")
+        expect(result.payload.to_json).not_to include("pushover-app-token-zzzz")
+      end
+
+      it "includes expire header effect" do
+        expect(result.response_effects[:set_expire_header]).to be_present
+      end
+    end
+
+    context "when pushover is already configured" do
+      around do |example|
+        previous = CommandTower.config.messaging.pushover.adapter
+        CommandTower.config.messaging.pushover.adapter = "fake"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+        example.run
+      ensure
+        CommandTower.config.messaging.pushover.adapter = previous
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      end
+
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      let(:user_key) { "pushover-user-key-efgh" }
+      let(:application_token) { "pushover-app-token-yyyy" }
+
+      it "maps service conflict to pushover_already_configured" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverAlreadyConfiguredError)
+        expect(result.errors.first.code).to eq("pushover_already_configured")
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/pushover/destroy_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/pushover/destroy_workflow_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::Pushover::DestroyWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+    end
+
+    context "when Pushover product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns capability unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverCapabilityUnavailableError)
+      end
+    end
+
+    context "when pushover is not configured" do
+      it "returns not configured failure" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverNotConfiguredError)
+      end
+    end
+
+    context "when destroying configured credentials" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns unconfigured payload" do
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:configured]).to eq(false)
+        expect(result.payload[:actions]).to eq(
+          canCreate: true,
+          canVerify: false,
+          canReplace: false,
+          canRemove: false
+        )
+      end
+
+      it "includes expire header effect" do
+        expect(result.response_effects[:set_expire_header]).to be_present
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/pushover/replace_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/pushover/replace_workflow_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::Pushover::ReplaceWorkflow do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        current_user: user,
+        user_key:,
+        application_token:,
+        auth_context: auth_context
+      )
+    end
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:user_key) { "pushover-user-key-efgh" }
+    let(:application_token) { "pushover-app-token-yyyy" }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+    end
+
+    context "when Pushover product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns capability unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverCapabilityUnavailableError)
+      end
+    end
+
+    context "when replacing existing credentials" do
+      around do |example|
+        previous = CommandTower.config.messaging.pushover.adapter
+        CommandTower.config.messaging.pushover.adapter = "fake"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+        example.run
+      ensure
+        CommandTower.config.messaging.pushover.adapter = previous
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      end
+
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns a new unverified payload without secrets" do
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:configured]).to eq(true)
+        expect(result.payload[:verificationState]).to eq("unverified")
+        expect(result.payload.to_json).not_to include("pushover-user-key-efgh")
+        expect(result.payload.to_json).not_to include("pushover-app-token-yyyy")
+      end
+
+      it "includes expire header effect" do
+        expect(result.response_effects[:set_expire_header]).to be_present
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/pushover/show_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/pushover/show_workflow_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::Pushover::ShowWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+    end
+
+    context "when Pushover product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns capability unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverCapabilityUnavailableError)
+      end
+    end
+
+    context "when pushover is not configured" do
+      it { expect(result).to be_success }
+
+      it "returns unconfigured payload" do
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:configured]).to eq(false)
+        expect(result.payload[:actions]).to eq(
+          canCreate: true,
+          canVerify: false,
+          canReplace: false,
+          canRemove: false
+        )
+      end
+
+      it "includes expire header effect" do
+        expect(result.response_effects[:set_expire_header]).to be_present
+      end
+    end
+
+    context "when pushover is configured" do
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns configured payload without secrets" do
+        expect(result.payload[:configured]).to eq(true)
+        expect(result.payload[:channelKey]).to eq("pushover")
+        expect(result.payload[:verificationState]).to eq("unverified")
+        expect(result.payload.to_json).not_to include("pushover-user-key-abcd")
+        expect(result.payload.to_json).not_to include("pushover-app-token-zzzz")
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/pushover/verify_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/pushover/verify_workflow_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::Pushover::VerifyWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(true)
+    end
+
+    context "when Pushover product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::PushoverProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns capability unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverCapabilityUnavailableError)
+      end
+    end
+
+    context "when pushover is not configured" do
+      it "returns not configured failure" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverNotConfiguredError)
+      end
+    end
+
+    context "when verification succeeds" do
+      around do |example|
+        previous = CommandTower.config.messaging.pushover.adapter
+        CommandTower.config.messaging.pushover.adapter = "fake"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+        example.run
+      ensure
+        CommandTower.config.messaging.pushover.adapter = previous
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      end
+
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+      end
+
+      it { expect(result).to be_success }
+
+      it "returns verified payload without secrets" do
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:verificationState]).to eq("verified")
+        expect(result.payload.to_json).not_to include("pushover-user-key-abcd")
+        expect(result.payload.to_json).not_to include("pushover-app-token-zzzz")
+      end
+
+      it "includes expire header effect" do
+        expect(result.response_effects[:set_expire_header]).to be_present
+      end
+    end
+
+    context "when Pushover rejects the user key" do
+      around do |example|
+        previous = CommandTower.config.messaging.pushover.adapter
+        CommandTower.config.messaging.pushover.adapter = "fake"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+        example.run
+      ensure
+        CommandTower.config.messaging.pushover.adapter = previous
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      end
+
+      before do
+        CommandTower::Services::Account::Pushover::Create.call(
+          user:,
+          user_key: "pushover-user-key-abcd",
+          application_token: "pushover-app-token-zzzz"
+        )
+        CommandTower::Messaging::Pushover::Adapters::FakeAdapter.fail_with = :invalid_user
+      end
+
+      it "maps invalid_user verification failure" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::PushoverVerificationFailedError)
+        expect(result.errors.first.code).to eq("pushover_invalid_user")
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/show_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/show_workflow_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::ShowWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user, auth_context: auth_context) }
+
+    let(:user) { create(:user, roles: ["member"]) }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Messaging::Execution::Adapters::Sms::Configuration)
+        .to receive(:sms_configured?).and_return(false)
+      allow(CommandTower::Identity::PhoneVerification::SmsConfiguration)
+        .to receive(:sms_ready?).and_return(false)
+      allow(CommandTower::Messaging::Execution::Adapters::Pushover::Configuration)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    it "returns the account payload with expire effect" do
+      expect(result).to be_success
+      expect(result.payload[:id]).to eq(user.id)
+      expect(result.payload[:capabilities]).to be_present
+      expect(result.response_effects[:set_expire_header]).to be_present
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/update_name_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/update_name_workflow_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::UpdateNameWorkflow do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        current_user: user,
+        first_name: first_name,
+        last_name: last_name,
+        auth_context: auth_context
+      )
+    end
+
+    let(:user) { create(:user, first_name: "Old", last_name: "Name", roles: ["member"]) }
+    let(:first_name) { "New" }
+    let(:last_name) { "Person" }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Messaging::Execution::Adapters::Sms::Configuration)
+        .to receive(:sms_configured?).and_return(false)
+      allow(CommandTower::Identity::PhoneVerification::SmsConfiguration)
+        .to receive(:sms_ready?).and_return(false)
+      allow(CommandTower::Messaging::Execution::Adapters::Pushover::Configuration)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    context "when the name update succeeds" do
+      it "returns the account payload with expire effect" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:id]).to eq(user.id)
+        expect(result.payload[:firstName]).to eq("New")
+        expect(result.payload[:lastName]).to eq("Person")
+        expect(result.response_effects[:set_expire_header]).to eq(auth_context.token_expires_at)
+      end
+    end
+
+    context "when the name update fails" do
+      let(:validation_error) do
+        CommandTower::Errors::ValidationError.new(details: { firstName: "is invalid" })
+      end
+
+      before do
+        allow(CommandTower::Services::Me::UpdateName).to receive(:call).and_return(
+          CommandTower::Services::ServiceResult.failure(errors: [validation_error])
+        )
+      end
+
+      it "returns unprocessable_entity" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to eq(validation_error)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/me/update_phone_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/me/update_phone_workflow_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Me::UpdatePhoneWorkflow do
+  describe ".call" do
+    subject(:result) do
+      described_class.call(
+        current_user: user,
+        phone_number: phone_number,
+        auth_context: auth_context
+      )
+    end
+
+    let(:user) { create(:user, :without_phone, roles: ["member"]) }
+    let(:phone_number) { "4155552671" }
+    let(:auth_context) do
+      CommandTower::Auth::AuthContext.new(
+        user: user,
+        token_expires_at: 1.hour.from_now.iso8601,
+        token_source: :header,
+        roles: user.roles,
+        principal_type: :user,
+        generated_token: nil
+      )
+    end
+
+    before do
+      allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(true)
+      allow(CommandTower::Messaging::Execution::Adapters::Sms::Configuration)
+        .to receive(:sms_configured?).and_return(false)
+      allow(CommandTower::Identity::PhoneVerification::SmsConfiguration)
+        .to receive(:sms_ready?).and_return(false)
+      allow(CommandTower::Messaging::Execution::Adapters::Pushover::Configuration)
+        .to receive(:pushover_configured?).and_return(false)
+    end
+
+    context "when the phone update succeeds" do
+      it "returns the account payload with the normalized phone number" do
+        expect(result).to be_success
+        expect(result.http_status).to eq(:ok)
+        expect(result.payload[:id]).to eq(user.id)
+        expect(result.payload[:phoneNumber]).to eq("+14155552671")
+        expect(result.payload[:phoneNumberValidated]).to eq(false)
+        expect(result.response_effects[:set_expire_header]).to eq(auth_context.token_expires_at)
+      end
+    end
+
+    context "when the SMS product gate is off" do
+      before do
+        allow(CommandTower::Services::Me::SmsProductGate).to receive(:enabled?).and_return(false)
+      end
+
+      it "returns service_unavailable" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:service_unavailable)
+        expect(result.errors.first).to be_a(CommandTower::Errors::Account::SmsCapabilityUnavailableError)
+      end
+    end
+
+    context "when the phone number is invalid" do
+      let(:phone_number) { "nope" }
+
+      it "returns unprocessable_entity" do
+        expect(result).to be_failure
+        expect(result.http_status).to eq(:unprocessable_entity)
+        expect(result.errors.first).to be_a(CommandTower::Errors::ValidationError)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/communications/produce_recipient_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/communications/produce_recipient_workflow_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Messaging::Communications::ProduceRecipientWorkflow, :messaging_accept do
+  let(:user) { create(:user) }
+  let(:notification_type_key) { "promo.job" }
+  let(:campaign_identity) { "campaign/job-1" }
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: [],
+        default_channels: [],
+        inbox_available: true,
+        user_configurable: false,
+        mandatory: false,
+        default_preference_state: { "channels" => {}, "inbox" => true },
+      ),
+    )
+  end
+
+  context "with a persisted user" do
+    subject(:result) do
+      described_class.call_from_job(
+        user_id: user.id,
+        notification_type_key:,
+        campaign_identity:,
+        title: "Hi",
+        body: "Body",
+        platform_enabled_channels: [],
+      )
+    end
+
+    it "produces for a reloaded user via call_from_job" do
+      expect(result).to be_success
+      expect(
+        CommandTower::Messaging::Communication.find_by(
+          user_id: user.id,
+          host_event_identity: "#{campaign_identity}/#{user.id}",
+        )
+      ).to be_present
+    end
+  end
+
+  context "when the user is missing" do
+    subject(:result) do
+      described_class.call_from_job(
+        user_id: 9_999_999_999,
+        notification_type_key:,
+        campaign_identity:,
+        title: "Hi",
+        body: "Body",
+        platform_enabled_channels: [],
+      )
+    end
+
+    it "returns not found without propagating when user is missing" do
+      expect(result).to be_failure
+      expect(result.meta[:propagate_to_job]).to eq(false)
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/error_mapping_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/error_mapping_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Messaging::ErrorMapping do
+  describe ".http_status_for" do
+    subject(:status) { described_class.http_status_for(error) }
+
+    context "when the error is ValidationError" do
+      let(:error) { CommandTower::Errors::ValidationError.new }
+
+      it { is_expected.to eq(:unprocessable_entity) }
+    end
+
+    context "when the error is RecipientUnresolvedError" do
+      let(:error) { CommandTower::Errors::Messaging::RecipientUnresolvedError.new }
+
+      it { is_expected.to eq(:unprocessable_entity) }
+    end
+
+    context "when the error is AcceptRejectedError" do
+      let(:error) { CommandTower::Errors::Messaging::AcceptRejectedError.new }
+
+      it { is_expected.to eq(:unprocessable_entity) }
+    end
+
+    context "when the error is IdempotencyConflictError" do
+      let(:error) { CommandTower::Errors::Messaging::IdempotencyConflictError.new }
+
+      it { is_expected.to eq(:conflict) }
+    end
+
+    context "when the error is NotFoundError" do
+      let(:error) { CommandTower::Errors::NotFoundError.new }
+
+      it { is_expected.to eq(:not_found) }
+    end
+
+    context "when the error is InternalError" do
+      let(:error) { CommandTower::Errors::InternalError.new }
+
+      it { is_expected.to eq(:internal_server_error) }
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/execution/deliver_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/execution/deliver_workflow_spec.rb
@@ -1,0 +1,756 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Messaging::Execution::DeliverWorkflow, :messaging_accept do
+  let(:user) { create(:user) }
+  let(:communication) do
+    create(
+      :messaging_communication,
+      user:,
+      host_event_identity: "exec-#{SecureRandom.hex(4)}",
+      accept_request_fingerprint: "fp",
+      status: "accepted",
+      execution_handoff_status: "enqueued",
+    )
+  end
+  let(:platform_enabled_channels) { %w[email] }
+  let!(:destination_plan) do
+    create(
+      :messaging_destination_plan,
+      communication:,
+      decision: {
+        "selected_channels" => %w[email],
+        "inbox_selected" => false,
+        "mandatory" => false,
+        "platform_enabled_channels" => platform_enabled_channels,
+        "excluded_destinations" => [],
+      },
+    )
+  end
+  let(:delivery) do
+    create(
+      :messaging_channel_delivery,
+      communication:,
+      channel_key: "email",
+      status: "queued",
+      execution_attempt_count: 0,
+    )
+  end
+
+  let(:success_adapter) do
+    CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(outcome: :success)
+  end
+
+  let(:enable_sms_platform!) do
+    destination_plan.update!(
+      decision: destination_plan.decision.merge(
+        "platform_enabled_channels" => %w[email sms],
+        "selected_channels" => %w[sms],
+      ),
+    )
+    allow(
+      CommandTower::Messaging::Execution::Adapters::Sms::Configuration,
+    ).to receive(:sms_configured?).and_return(true)
+  end
+
+  context "when the delivery is planned" do
+    before { delivery.update!(status: "planned") }
+
+    subject(:invoke) do
+      described_class.call(channel_delivery_id: delivery.id, executor: success_adapter)
+    end
+
+    before { invoke }
+
+    it "does not execute planned deliveries" do
+      expect(delivery.reload.status).to eq("planned")
+      expect(delivery.execution_attempt_count).to eq(0)
+      expect(CommandTower::Messaging::DeliveryAttempt.count).to eq(0)
+    end
+  end
+
+  context "when queued work succeeds" do
+    subject(:invoke) do
+      described_class.call(channel_delivery_id: delivery.id, executor: success_adapter)
+    end
+
+    before { invoke }
+
+    it "claims queued work, writes an attempt, and marks accepted_by_provider on success" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(delivery.execution_attempt_count).to eq(1)
+      expect(delivery.execution_claimed_at).to be_present
+      expect(delivery.delivery_attempts.sole.status).to eq("succeeded")
+      expect(delivery.delivery_attempts.sole.finished_at).to be_present
+    end
+  end
+
+  context "when the adapter returns retryable failure" do
+    let(:adapter) do
+      CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(
+        outcome: :retryable_failure,
+        error_code: "provider_timeout",
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "maps retryable adapter failure to matched attempt and delivery statuses" do
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("provider_timeout")
+    end
+  end
+
+  context "when the adapter returns terminal failure" do
+    let(:adapter) do
+      CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(
+        outcome: :terminal_failure,
+        error_code: "invalid_recipient",
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "maps terminal adapter failure to matched attempt and delivery statuses" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+    end
+  end
+
+  context "when no executor is injected under :test delivery" do
+    around do |example|
+      previous_fake = CommandTower.config.messaging.allow_fake_adapter
+      CommandTower.config.messaging.allow_fake_adapter = false
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous_fake
+    end
+
+    before do
+      ActionMailer::Base.deliveries.clear
+      communication.update!(metadata: { "deep_link" => "https://example.com/go" })
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+    before { invoke }
+
+    it "uses EmailAdapter under :test delivery when no executor is injected" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(delivery.delivery_attempts.sole.status).to eq("succeeded")
+      expect(delivery.delivery_attempts.sole.normalized_provider_status).to eq("accepted")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+      expect(ActionMailer::Base.deliveries.last.to).to eq([user.email])
+      expect(ActionMailer::Base.deliveries.last.text_part.body.to_s).to include("https://example.com/go")
+      expect(ActionMailer::Base.deliveries.last.html_part.body.to_s).to include("https://example.com/go")
+      expect(CommandTower::Messaging::DeliveryAttempt.column_names).not_to include(
+        "rendered_html", "rendered_text", "subject", "html_body", "text_body",
+      )
+      expect(delivery.delivery_attempts.sole.attributes.values.join).not_to include(communication.body)
+    end
+  end
+
+  context "when :smtp contract is incomplete" do
+    around do |example|
+      previous_fake = CommandTower.config.messaging.allow_fake_adapter
+      previous_method = CommandTower.config.email.delivery_method
+      previous_settings = Rails.configuration.action_mailer.smtp_settings.dup
+      CommandTower.config.messaging.allow_fake_adapter = false
+      CommandTower.config.email.delivery_method = :smtp
+      Rails.configuration.action_mailer.smtp_settings = previous_settings.merge(
+        address: "smtp.example.com",
+        port: 587,
+        user_name: "",
+        password: "",
+        authentication: "plain",
+        enable_starttls_auto: true,
+      )
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous_fake
+      CommandTower.config.email.delivery_method = previous_method
+      Rails.configuration.action_mailer.smtp_settings = previous_settings
+    end
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+    before { invoke }
+
+    it "fails closed with UnconfiguredAdapter when :smtp contract is incomplete" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("adapter_unconfigured")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+
+  context "when allow_fake_adapter is enabled" do
+    around do |example|
+      previous = CommandTower.config.messaging.allow_fake_adapter
+      CommandTower.config.messaging.allow_fake_adapter = true
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous
+    end
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+    before { invoke }
+
+    it "uses FakeAdapter when allow_fake_adapter is enabled" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+
+  context "when allow_fake_adapter is false and MESSAGING_ALLOW_FAKE_ADAPTER ENV is true" do
+    around do |example|
+      previous = CommandTower.config.messaging.allow_fake_adapter
+      previous_env = ENV["MESSAGING_ALLOW_FAKE_ADAPTER"]
+      CommandTower.config.messaging.allow_fake_adapter = false
+      ENV["MESSAGING_ALLOW_FAKE_ADAPTER"] = "true"
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous
+      ENV["MESSAGING_ALLOW_FAKE_ADAPTER"] = previous_env
+    end
+
+    before { ActionMailer::Base.deliveries.clear }
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+    before { invoke }
+
+    it "ignores MESSAGING_ALLOW_FAKE_ADAPTER ENV when allow_fake_adapter is false" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(ActionMailer::Base.deliveries.size).to eq(1)
+    end
+  end
+
+  context "when an executor is injected with allow_fake_adapter enabled" do
+    around do |example|
+      previous = CommandTower.config.messaging.allow_fake_adapter
+      CommandTower.config.messaging.allow_fake_adapter = true
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous
+    end
+
+    let(:adapter) do
+      CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(
+        outcome: :terminal_failure,
+        error_code: "injected",
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "prefers an injected executor over EmailAdapter and FakeAdapter" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("injected")
+    end
+  end
+
+  context "when the adapter raises an unexpected exception" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before { allow(adapter).to receive(:call).and_raise(RuntimeError, "secret boom details") }
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    it "maps unexpected exceptions to internal_adapter_error with matched statuses" do
+      expect { invoke }.not_to raise_error
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("internal_adapter_error")
+      expect(delivery.delivery_attempts.sole.error_class).to eq("RuntimeError")
+      expect(delivery.delivery_attempts.sole.attributes.values.join).not_to include("secret boom details")
+    end
+  end
+
+  context "when the adapter returns something other than an AdapterResult" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before { allow(adapter).to receive(:call).and_return(true) }
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "treats non-AdapterResult returns as unexpected failure" do
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("internal_adapter_error")
+    end
+  end
+
+  context "when attempt creation fails" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before do
+      allow(adapter).to receive(:call)
+      allow(CommandTower::Messaging::DeliveryAttempt).to receive(:create!).and_raise(
+        ActiveRecord::StatementInvalid.new("insert failed"),
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "does not call the adapter when attempt creation fails" do
+      expect(adapter).not_to have_received(:call)
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(CommandTower::Messaging::DeliveryAttempt.count).to eq(0)
+    end
+  end
+
+  context "after retryable failure" do
+    before do
+      failure = CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(outcome: :retryable_failure)
+      described_class.call(channel_delivery_id: delivery.id, executor: failure)
+    end
+
+    subject(:second_run) do
+      described_class.call(channel_delivery_id: delivery.id, executor: success_adapter)
+    end
+
+    it "does not allow an immediate re-run to bypass Recovery after retryable failure" do
+      expect(delivery.reload.status).to eq("failed_retryable")
+      second_run
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.count).to eq(1)
+    end
+  end
+
+  context "when the delivery is already accepted_by_provider" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before do
+      delivery.update!(status: "accepted_by_provider", execution_attempt_count: 1)
+      allow(adapter).to receive(:call)
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "is a no-op when already accepted_by_provider" do
+      expect(adapter).not_to have_received(:call)
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+    end
+  end
+
+  context "under concurrent workers" do
+    let(:barrier) { Queue.new }
+    let(:results) { Queue.new }
+
+    before do
+      threads = Array.new(2) do
+        Thread.new do
+          barrier.pop
+          results << described_class.call(
+            channel_delivery_id: delivery.id,
+            executor: CommandTower::Messaging::Execution::Adapters::FakeAdapter.new,
+          )
+        end
+      end
+
+      2.times { barrier << :go }
+      threads.each(&:join)
+    end
+
+    it "prevents duplicate claims under concurrent workers" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(delivery.execution_attempt_count).to eq(1)
+      expect(delivery.delivery_attempts.count).to eq(1)
+    end
+  end
+
+  context "when the SMS adapter is disabled after readiness resolves the channel" do
+    around do |example|
+      previous_fake = CommandTower.config.messaging.allow_fake_adapter
+      CommandTower.config.messaging.allow_fake_adapter = false
+      example.run
+    ensure
+      CommandTower.config.messaging.allow_fake_adapter = previous_fake
+      CommandTower.config.messaging.sms.adapter = "disabled"
+    end
+
+    before do
+      allow(
+        CommandTower::Messaging::Execution::Adapters::Sms::Configuration,
+      ).to receive(:sms_configured?).and_call_original
+      user.update!(phone_number: "+14155552671", phone_number_validated: true)
+      delivery.update!(channel_key: "sms")
+      destination_plan.update!(
+        decision: destination_plan.decision.merge(
+          "platform_enabled_channels" => %w[email sms],
+          "selected_channels" => %w[sms],
+        ),
+      )
+      CommandTower.config.messaging.sms.adapter = "disabled"
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+    before { invoke }
+
+    it "finalizes disabled SMS adapter as adapter_unconfigured after readiness fails platform_configured" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("adapter_unconfigured")
+    end
+  end
+
+  context "when SMS is ready and FakeAdapter succeeds" do
+    let(:adapter) { CommandTower::Messaging::Execution::Adapters::FakeAdapter.new(outcome: :success) }
+
+    before do
+      enable_sms_platform!
+      user.update!(phone_number: "+14155552671", phone_number_validated: true)
+      delivery.update!(channel_key: "sms")
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "resolves verified Identity phone for SMS and persists FakeAdapter success" do
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(delivery.delivery_attempts.sole.status).to eq("succeeded")
+      expect(adapter.last_request.channel_key).to eq("sms")
+      expect(adapter.last_request.rendered).to be_a(CommandTower::Messaging::Rendering::RenderedSmsPayload)
+      expect(adapter.last_request.rendered.recipient_address).to eq("+14155552671")
+      expect(adapter.last_request.rendered.body).to be_present
+    end
+  end
+
+  context "when the adapter must not be invoked because readiness resolution fails" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before { allow(adapter).to receive(:call) }
+
+    context "when SMS phone is unverified" do
+      before do
+        enable_sms_platform!
+        user.update!(phone_number: "+14155552671", phone_number_validated: false)
+        delivery.update!(channel_key: "sms")
+      end
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+      before { invoke }
+
+      it "finalizes unverified SMS phone as recipient_unverified without calling the adapter" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.error_code).to eq("recipient_unverified")
+        expect(adapter).not_to have_received(:call)
+      end
+    end
+
+    context "when SMS phone is missing" do
+      before do
+        enable_sms_platform!
+        user.update!(phone_number: nil, phone_number_validated: false)
+        delivery.update!(channel_key: "sms")
+      end
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+      before { invoke }
+
+      it "finalizes missing SMS phone as recipient_missing without calling the adapter" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.error_code).to eq("recipient_missing")
+        expect(adapter).not_to have_received(:call)
+      end
+    end
+
+    context "when Accept-time enablement no longer includes the channel" do
+      before do
+        enable_sms_platform!
+        user.update!(phone_number: "+14155552671", phone_number_validated: true)
+        delivery.update!(channel_key: "sms")
+        destination_plan.update!(
+          decision: destination_plan.decision.merge("platform_enabled_channels" => %w[email]),
+        )
+      end
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+      before { invoke }
+
+      it "finalizes platform_disabled when Accept-time enablement no longer includes the channel" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.error_code).to eq("platform_disabled")
+        expect(adapter).not_to have_received(:call)
+      end
+    end
+
+    context "when email_validated regresses" do
+      before { user.update!(email_validated: false) }
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+      before { invoke }
+
+      it "finalizes email_validated regression as recipient_unverified" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.error_code).to eq("recipient_unverified")
+        expect(adapter).not_to have_received(:call)
+      end
+    end
+  end
+
+  context "when the recipient is missing at render time" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before do
+      allow(adapter).to receive(:call)
+      allow(CommandTower::Messaging::Rendering::ChannelRenderer).to receive(:render)
+      user.update!(email: "")
+      ActionMailer::Base.deliveries.clear
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "finalizes missing recipients as recipient_missing without calling the adapter" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("recipient_missing")
+      expect(CommandTower::Messaging::Rendering::ChannelRenderer).not_to have_received(:render)
+      expect(adapter).not_to have_received(:call)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+
+  context "when template rendering fails" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before do
+      allow(adapter).to receive(:call)
+      allow(CommandTower::Messaging::Rendering::ChannelRenderer).to receive(:render).and_raise(
+        CommandTower::Messaging::Rendering::RenderError.new(code: "render_failed", error_class: "Errno::ENOENT"),
+      )
+      ActionMailer::Base.deliveries.clear
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "finalizes template failures as render_failed without calling the adapter" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("render_failed")
+      expect(adapter).not_to have_received(:call)
+      expect(ActionMailer::Base.deliveries).to be_empty
+    end
+  end
+
+  context "when EmailAdapter reports a retryable transport failure" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::Email::Adapter) }
+
+    before do
+      allow(adapter).to receive(:call).and_return(
+        CommandTower::Messaging::Execution::AdapterResult.build(
+          outcome: :retryable_failure,
+          error_code: "smtp_transient",
+        ),
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "maps EmailAdapter retryable transport failures to matched retryable statuses" do
+      expect(delivery.reload.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_retryable")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("smtp_transient")
+    end
+  end
+
+  context "when EmailAdapter reports a terminal transport failure" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::Email::Adapter) }
+
+    before do
+      allow(adapter).to receive(:call).and_return(
+        CommandTower::Messaging::Execution::AdapterResult.build(
+          outcome: :terminal_failure,
+          error_code: "smtp_rejected",
+        ),
+      )
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "maps EmailAdapter terminal transport failures to matched terminal statuses" do
+      expect(delivery.reload.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+      expect(delivery.delivery_attempts.sole.error_code).to eq("smtp_rejected")
+    end
+  end
+
+  context "when the workflow renders before invoking the adapter" do
+    let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+    before do
+      allow(adapter).to receive(:call) do |request:|
+        expect(request).to be_a(CommandTower::Messaging::Execution::AdapterRequest)
+        expect(request.rendered).to be_a(CommandTower::Messaging::Rendering::RenderedPayload)
+        expect(request.rendered.recipient_address).to eq(user.email)
+        CommandTower::Messaging::Execution::AdapterResult.build(outcome: :success)
+      end
+    end
+
+    subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+    before { invoke }
+
+    it "renders before invoking the adapter and does not persist rendered bodies" do
+      expect(adapter).to have_received(:call)
+      expect(delivery.reload.status).to eq("accepted_by_provider")
+      expect(CommandTower::Messaging::DeliveryAttempt.column_names).not_to include("rendered_html")
+      expect(CommandTower::Messaging::ChannelDelivery.column_names).not_to include("rendered_html")
+    end
+  end
+
+  context "pushover handoff boundary" do
+    let(:platform_enabled_channels) { %w[pushover] }
+    let(:endpoint) do
+      view = CommandTower::Messaging::Endpoints.create(
+        owner_user_id: user.id,
+        channel_key: "pushover",
+        credentials: {
+          user_key: "u" + ("c" * 30),
+          application_token: "t" + ("d" * 30),
+        },
+      )
+      record = CommandTower::Messaging::Endpoint.find(view.id)
+      record.update!(verification_state: "verified", verified_at: Time.current)
+      record
+    end
+
+    around do |example|
+      previous = CommandTower.config.messaging.pushover.adapter
+      previous_fake = CommandTower.config.messaging.allow_fake_adapter
+      CommandTower.config.messaging.pushover.adapter = "fake"
+      # Real Pushover::Adapter must run — platform FakeAdapter succeeds without provider status.
+      CommandTower.config.messaging.allow_fake_adapter = false
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+      example.run
+    ensure
+      CommandTower.config.messaging.pushover.adapter = previous
+      CommandTower.config.messaging.allow_fake_adapter = previous_fake
+      CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      CommandTower::Messaging::Pushover::Adapters::FakeAdapter.reset!
+    end
+
+    before do
+      endpoint
+      delivery.update!(channel_key: "pushover")
+      destination_plan.update!(
+        decision: destination_plan.decision.merge(
+          "selected_channels" => %w[pushover],
+          "platform_enabled_channels" => platform_enabled_channels,
+        ),
+      )
+    end
+
+    context "when delivering via readiness resolved_endpoint_id" do
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+      before { invoke }
+
+      it "delivers an explicitly handed-off Pushover ChannelDelivery via readiness resolved_endpoint_id" do
+        expect(delivery.reload.status).to eq("accepted_by_provider")
+        expect(delivery.delivery_attempts.sole.status).to eq("succeeded")
+        expect(delivery.delivery_attempts.sole.normalized_provider_status).to eq("accepted")
+        expect(delivery.delivery_attempts.sole.provider_message_id).to be_present
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages.size).to eq(1)
+      end
+    end
+
+    context "when endpoint is revoked after handoff (TOCTOU)" do
+      before { endpoint.update!(lifecycle_state: "revoked", revoked_at: Time.current) }
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+      before { invoke }
+
+      it "terminals without calling Transport when endpoint is revoked after handoff (TOCTOU)" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.status).to eq("failed_terminal")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages).to be_empty
+      end
+    end
+
+    context "when verification is reset after handoff" do
+      before { endpoint.update!(verification_state: "unverified", verified_at: nil) }
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+      before { invoke }
+
+      it "terminals without Transport when verification is reset after handoff" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages).to be_empty
+      end
+    end
+
+    context "when adapter is disabled after handoff" do
+      before do
+        CommandTower.config.messaging.pushover.adapter = "disabled"
+        CommandTower::Messaging::Pushover::Transport.reset_adapter!
+      end
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id) }
+
+      before { invoke }
+
+      it "terminals when adapter is disabled after handoff" do
+        expect(delivery.reload.status).to eq("failed_terminal")
+        expect(delivery.delivery_attempts.sole.error_code).to eq("adapter_unconfigured")
+        expect(CommandTower::Messaging::Pushover::Adapters::FakeAdapter.messages).to be_empty
+      end
+    end
+
+    context "when the rendered payload is inspected for secrets" do
+      let(:adapter) { instance_double(CommandTower::Messaging::Execution::Adapters::FakeAdapter) }
+
+      before do
+        allow(adapter).to receive(:call) do |request:|
+          expect(request.rendered).to be_a(CommandTower::Messaging::Rendering::RenderedPushoverPayload)
+          expect(request.rendered.recipient_address).to eq(endpoint.id.to_s)
+          expect(request.rendered.to_h.values.join).not_to include("cccccccccc")
+          CommandTower::Messaging::Execution::AdapterResult.build(outcome: :success)
+        end
+      end
+
+      subject(:invoke) { described_class.call(channel_delivery_id: delivery.id, executor: adapter) }
+
+      before { invoke }
+
+      it "passes opaque endpoint id into the rendered payload without secrets" do
+        expect(adapter).to have_received(:call)
+      end
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/handoff/process_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/handoff/process_workflow_spec.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Messaging::Handoff::ProcessWorkflow, :messaging_accept do
+  let(:user) { create(:user) }
+  let(:notification_type_key) { "booking.success" }
+  let(:platform_enabled_channels) { %w[email sms] }
+
+  before do
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: notification_type_key,
+        allowed_channels: %w[email sms],
+        default_channels: %w[email],
+        inbox_available: true,
+        user_configurable: true,
+        mandatory: false,
+        default_preference_state: {
+          "channels" => { "email" => true, "sms" => true },
+          "inbox" => true,
+        },
+      ),
+    )
+  end
+
+  let(:accept) do
+    lambda do |**overrides|
+      CommandTower::Messaging::Accept::Coordinator.call(
+        **default_accept_attrs(user:, notification_type_key:, platform_enabled_channels:, **overrides),
+      )
+    end
+  end
+
+  let(:communication_for) do
+    lambda do |result|
+      CommandTower::Messaging::Communication.find(result.communication_id)
+    end
+  end
+
+  describe "channel plans" do
+    before do
+      allow(
+        CommandTower::Messaging::Execution::Adapters::Sms::Configuration,
+      ).to receive(:sms_configured?).and_return(true)
+      user.update!(phone_number: "+14155552671", phone_number_validated: true)
+    end
+
+    let(:accept_result) { accept.call(message_overrides: { "channels_add" => %w[sms] }) }
+    let(:communication) { communication_for.call(accept_result) }
+
+    subject(:invoke) { described_class.call(communication_id: communication.id) }
+
+    it "transitions planned channel deliveries to queued and marks handoff enqueued" do
+      expect(communication.execution_handoff_status).to eq("pending")
+      expect(communication.channel_deliveries.pluck(:status).uniq).to eq(["planned"])
+
+      invoke
+      communication.reload
+
+      expect(communication.execution_handoff_status).to eq("enqueued")
+      expect(communication.channel_deliveries.pluck(:status).uniq).to eq(["queued"])
+      expect(CommandTower::Messaging::DeliveryAttempt.count).to eq(0)
+    end
+  end
+
+  describe "inbox-only and empty optional plans" do
+    context "when inbox-only with no channel deliveries" do
+      before do
+        upsert_notification_preference!(
+          recipient_id: user.id,
+          notification_type_key:,
+          preference_state: build_preference_state(
+            channels: { "email" => false, "sms" => false },
+            inbox: true,
+          ),
+        )
+      end
+
+      let(:accept_result) { accept.call }
+
+      subject(:invoke) { described_class.call(communication_id: accept_result.communication_id) }
+
+      before { invoke }
+
+      let(:communication) { communication_for.call(accept_result).reload }
+
+      it "marks handoff complete for inbox-only with no channel deliveries" do
+        expect(communication.execution_handoff_status).to eq("complete")
+        expect(communication.channel_deliveries).to be_empty
+        expect(communication.inbox_item).to be_present
+      end
+    end
+
+    context "when the plan is an empty optional plan" do
+      before do
+        upsert_notification_preference!(
+          recipient_id: user.id,
+          notification_type_key:,
+          preference_state: build_preference_state(
+            channels: { "email" => false, "sms" => false },
+            inbox: false,
+          ),
+        )
+      end
+
+      let(:accept_result) { accept.call }
+
+      subject(:invoke) { described_class.call(communication_id: accept_result.communication_id) }
+
+      before { invoke }
+
+      it "marks handoff complete for an empty optional plan" do
+        expect(communication_for.call(accept_result).reload.execution_handoff_status).to eq("complete")
+        expect(CommandTower::Messaging::ChannelDelivery.count).to eq(0)
+      end
+    end
+  end
+
+  describe "idempotency" do
+    context "when already enqueued" do
+      let(:accept_result) { accept.call }
+      let(:communication) { communication_for.call(accept_result) }
+
+      before do
+        described_class.call(communication_id: communication.id)
+        communication.reload
+      end
+
+      subject(:invoke) { described_class.call(communication_id: communication.id) }
+
+      it "is a no-op when already enqueued" do
+        expect(communication.execution_handoff_status).to eq("enqueued")
+
+        expect { invoke }.not_to(change { communication.reload.updated_at })
+        expect(communication.channel_deliveries.pluck(:status).uniq).to eq(["queued"])
+      end
+    end
+
+    context "when already complete" do
+      before do
+        upsert_notification_preference!(
+          recipient_id: user.id,
+          notification_type_key:,
+          preference_state: build_preference_state(
+            channels: { "email" => false, "sms" => false },
+            inbox: false,
+          ),
+        )
+      end
+
+      let(:accept_result) { accept.call }
+      let(:communication) { communication_for.call(accept_result) }
+
+      before do
+        described_class.call(communication_id: communication.id)
+        communication.reload
+      end
+
+      subject(:invoke) { described_class.call(communication_id: communication.id) }
+
+      it "is a no-op when already complete" do
+        expect(communication.execution_handoff_status).to eq("complete")
+        expect { invoke }.not_to(change { communication.reload.updated_at })
+      end
+    end
+  end
+
+  describe "execution failure" do
+    before do
+      allow(CommandTower::Messaging::Handoff::AdvanceCommunication)
+        .to receive(:call)
+        .and_raise(ActiveRecord::RecordInvalid.new(CommandTower::Messaging::ChannelDelivery.new))
+    end
+
+    context "when handoff processing fails" do
+      let(:accept_result) { accept.call }
+      let(:communication) { communication_for.call(accept_result) }
+
+      subject(:workflow_result) { described_class.call(communication_id: communication.id) }
+
+      it "marks handoff failed and returns a job-propagating failure" do
+        expect(workflow_result).to be_failure
+        expect(workflow_result.meta[:propagate_to_job]).to eq(true)
+        expect(communication.reload.execution_handoff_status).to eq("failed")
+      end
+    end
+
+    context "when invoked from a job" do
+      let(:accept_result) { accept.call }
+      let(:communication) { communication_for.call(accept_result) }
+
+      subject(:invoke) { described_class.call_from_job(communication_id: communication.id) }
+
+      it "raises through call_from_job for ActiveJob observability" do
+        expect { invoke }.to raise_error(CommandTower::Errors::InternalError)
+      end
+    end
+  end
+
+  describe "missing communication" do
+    subject(:workflow_result) { described_class.call(communication_id: -1) }
+
+    it "returns success noop without raising" do
+      expect(workflow_result).to be_success
+      expect(workflow_result.payload[:outcome]).to eq(:noop)
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/inbox/core_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/inbox/core_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe "Messaging inbox workflows", :messaging_inbox do
+  let(:user) { create(:user) }
+
+  context "when listing inbox items" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) do
+      CommandTower::Workflows::Messaging::Inbox::ListWorkflow.call(user:, limit: 50, offset: 0, scope: "inbox")
+    end
+
+    it "serializes a listed inbox item" do
+      expect(result).to be_success
+      expect(result.payload.map { |entry| entry[:id] }).to include(item.id)
+    end
+  end
+
+  context "when opening an inbox item" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) { CommandTower::Workflows::Messaging::Inbox::OpenWorkflow.call(user:, inbox_item_id: item.id) }
+
+    it "opens an item through its workflow" do
+      expect(result).to be_success
+      expect(result.payload[:read]).to be(true)
+    end
+  end
+
+  context "when bulk marking inbox items read" do
+    let!(:item) { create_inbox_for(user:) }
+
+    subject(:result) do
+      CommandTower::Workflows::Messaging::Inbox::BulkReadWorkflow.call(user:, inbox_item_ids: [item.id])
+    end
+
+    it "serializes a bulk read result" do
+      expect(result).to be_success
+      expect(result.payload).to include(ids: [item.id], changedCount: 1)
+    end
+  end
+end

--- a/spec/workflows/command_tower/workflows/messaging/preferences/show_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/messaging/preferences/show_workflow_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Messaging::Preferences::ShowWorkflow, :messaging_preferences do
+  let(:user) { create(:user) }
+
+  before do
+    CommandTower.config.messaging.platform_enabled_channels = -> { %w[email] }
+    register_and_seal_notification_types(
+      build_notification_type_declaration(
+        key: "booking_confirmation",
+        label: "Booking Confirmation",
+        category_key: "reservations",
+        category_label: "Reservations",
+        category_order: 10,
+        type_order: 10,
+        allowed_channels: %w[email],
+        default_channels: %w[email],
+        settings_visible: true,
+      ),
+    )
+  end
+
+  after do
+    CommandTower.config.messaging.platform_enabled_channels = -> { [] }
+  end
+
+  subject(:result) { described_class.call(user:) }
+
+  it "returns a serialized catalog payload" do
+    expect(result).to be_success
+    expect(result.http_status).to eq(:ok)
+    expect(result.payload.keys).to contain_exactly(:categories)
+  end
+end

--- a/spec/workflows/command_tower/workflows/profile/show_workflow_spec.rb
+++ b/spec/workflows/command_tower/workflows/profile/show_workflow_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe CommandTower::Workflows::Profile::ShowWorkflow do
+  describe ".call" do
+    subject(:result) { described_class.call(current_user: user) }
+
+    let(:user) { create(:user, roles: ["member"]) }
+
+    it "returns the UserSerializer payload" do
+      expect(result).to be_success
+      expect(result.payload).to include(id: user.id, email: user.email)
+      expect(result.payload).not_to have_key(:capabilities)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Lands the **Me** slice of the 0.10.0 merge train (single commit on top of auth).
- Account/profile, name/password, inbox consume, preferences, phone, Pushover.
- Base: `release/0.10.0-auth`.

## Test plan

- [ ] CI green (stacked on auth)
- [ ] `spec/requests/command_tower/me/**` and profile specs


Made with [Cursor](https://cursor.com)