### PR TITLE
0.10.0 docs: host guides and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,135 @@
 # CommandTower
-This is an API only base engine to build on top of. This Engine takes care of all Authentication, Token Refresh, and RBAC Roles so that you do not have to! For all applications, you can get right to work on implementing the code directly related to your project rather than dealing with the administrative overhead.
 
-While this gem is heavily opinionated, everything can be configured to your liking.
+CommandTower is a mountable **Rails engine** that provides shared platform capabilities for host applications: JWT authentication, RBAC authorization, account/Me surfaces, messaging HTTP (inbox, preferences, endpoints), admin announcements, and shared test factories.
 
-## Installation
-Add this line to your application's Gemfile:
+Hosts mount the engine, configure secrets and product policy, and build product features on top—without re-implementing platform foundations.
+
+The engine is opinionated and configurable. Architecture follows a stable layer map (workflows orchestrate; services implement capabilities). See [Architecture](docs/architecture.md).
+
+## Quick start
 
 ```ruby
+# Gemfile
 gem "command_tower"
 ```
 
-And then execute:
 ```bash
-$ bundle
+bundle install
+bin/rails command_tower:install
+bin/rails db:migrate
+bin/rails command_tower:doctor
 ```
 
-Or install it yourself as:
-```bash
-$ gem install command_tower
+Full install, upgrade, configuration, and troubleshooting: [Initializing CommandTower](docs/initializing.md).
+
+After install, complete RBAC, feature gates, and a Me smoke check: [Host integration guide](docs/host_integration_guide.md) (**start here for a new Rails host**).
+
+## Architecture
+
+```text
+Controller / Job → Workflow → Shared Sequences / Services → Models & Clients
 ```
 
-## Initializing CommandTower
-Please follow all steps in [Initializing CommandTower](docs/initializing.md)
+- Controllers are transport adapters (one workflow per action).
+- Workflows orchestrate a business action.
+- Services (including `CommandTower::ServiceBase`) implement one capability.
 
+See [Architecture](docs/architecture.md) and [ServiceBase](app/services/command_tower/README.md).
 
-## Available Routes
+## Documentation
 
-For more info, check out [Controllers ReadMe](docs/controllers.md)
+| Guide | Purpose |
+|-------|---------|
+| [Host integration](docs/host_integration_guide.md) | **Start here** — step-by-step new Rails host path |
+| [Upgrades](docs/upgrades/README.md) | Release upgrade summaries (see [0.10.0](docs/upgrades/0.10.0.md)) |
+| [Initializing](docs/initializing.md) | Install, configure, migrate, doctor, upgrades |
+| [Testing](docs/testing.md) | Shared FactoryBot / `CommandTower::Testing` |
+| [Architecture](docs/architecture.md) | Layer map for hosts and contributors |
+| [Controllers / routes](docs/controllers.md) | Engine route areas (index) |
+| [API reference](docs/api_reference.md) | Endpoint catalog (detailed contracts) |
+| [Extending](docs/extending.md) | Stable extension points / do-not-extend |
+| [Models](docs/models.md) | `User`, `UserSecret`, reopening classes |
+| [Authentication](docs/authentication.md) | JWT auth quick start |
+| [Authorization](docs/authorization.md) | RBAC quick start |
+| [Authentication & authorization guide](docs/authentication_authorization_guide.md) | Deep authn + RBAC |
+| [Cookie authentication](docs/cookie_authentication_guide.md) | HttpOnly cookies, CORS, CSRF |
+| [Sensitive changes](docs/sensitive_routes.md) | Verifier token / session invalidation |
+| [Messaging](docs/messaging_integration_guide.md) | Current messaging surfaces |
+| [Pagination](docs/pagination.md) | Pagination helpers |
+| [ServiceBase](app/services/command_tower/README.md) | Service capability base |
+| [Password reset workflow](docs/password_reset_workflow.md) | Forgot-password flow |
+| [Change password workflow](docs/change_password_workflow.md) | Authenticated password change |
+| [Email verification workflow](docs/email_verification_workflow.md) | Email verification flow |
 
-Additionally, You can check out [RSpec Integration Testing](/spec/integration_test)
+## Installation and configuration
 
-## Available Models
+See [Initializing CommandTower](docs/initializing.md) for:
 
-CommandTower provides several Models at the in the root namespace. Core Models like `User` and `UserSecret` are readily available. Don't forget! You can add additional methods to these classes by opening them back up.
+- `command_tower:install` / `install:migrations`
+- Configure generator flags (`SKIP_CONFIGURE`, `SKIP_MOUNT`, `FORCE`)
+- Schema ownership (**AD-SCH-01**)
+- Secrets and doctor checks
+- Existing customized hosts
 
-For more info, check out [Models ReadMe](docs/models.md)
+## Testing
 
-## Authentication (JWT BearerToken)
-Authentication ensures that we know which user is requesting the action. When the Engine is unable to authenticate, a `401` status code is returned.
+Shared factories for hosts:
 
-For more info, check out [Authentication ReadMe](docs/authentication.md)
+```ruby
+require "command_tower/testing"
+CommandTower::Testing.install!
+```
+
+Details: [Testing with CommandTower](docs/testing.md).
+
+Engine HTTP coverage lives primarily under `spec/requests/`. Residual journey coverage may remain under `spec/integration_test/`.
+
+## Routes
+
+Engine routes cover Auth, Me (profile, inbox, preferences, phone, Pushover), and Admin messaging announcements. Index: [Controllers](docs/controllers.md). Contracts: [API reference](docs/api_reference.md).
+
+## Models
+
+Core models such as `User` and `UserSecret` are available for hosts to use and reopen carefully. See [Models](docs/models.md).
+
+## Authentication (JWT)
+
+Authentication establishes identity (`401` when it fails).
+
+- **Engine controllers** use `authenticate_request!` / `authorize_request!` (Authentication/Authorization boundaries) and return the application envelope.
+- **Host controllers** may use provisional `before_action :authenticate_user!` (failure shapes can differ — see the deep guide).
+
+- Quick start: [Authentication](docs/authentication.md)
+- Deep guide: [Authentication & authorization](docs/authentication_authorization_guide.md)
+- Web / SPA cookies: [Cookie authentication](docs/cookie_authentication_guide.md)
+
+Cookie mode supports HttpOnly JWT cookies, SameSite, optional double-submit CSRF, and secure cookies in production.
 
 ## Authorization (RBAC)
-Authorization is only done after authentication. This is the act of ensuring that the user can perform the action it is requesting. Put differently, I know who you are, but I need to validate you have permissions to complete the action. When the engine is unable to authorize the user, a `403` status code is returned.
 
-For more info, check out [Authentication ReadMe](docs/authorization.md)
+Authorization establishes permission after authentication (`403` when it fails).
 
-## Sensitive Changes
+Engine defaults ship `owner` and `admin` (announcements). Hosts **must** supply `rbac_groups.yml` entities for Me/Auth surfaces (fail-closed). Host controllers may use provisional `authorize_user!` after `authenticate_user!`.
 
-For more info, check out [Sensitive Routes](docs/sensitive_routes.md)
+- Quick start: [Authorization](docs/authorization.md)
+- Deep guide: [Authentication & authorization](docs/authentication_authorization_guide.md)
 
-## ServiceBase
-ServiceBase is built on top of Interactor. The ServiceBase is the heart of all logic for CommandTower. It includes Logging and enhanced ArgumentValidation that can directly return back to the API request.
+## Sensitive changes
 
-For more info, check out [ServiceBase ReadMe](app/services/command_tower/README.md)
+JWT tokens embed a `verifier_token` bound to the user. Rotating the verifier invalidates outstanding sessions. See [Sensitive changes](docs/sensitive_routes.md).
+
+## Messaging
+
+Modern messaging surfaces: Me Inbox consume, Produce / ProduceMany emit, admin announcements. See [Messaging](docs/messaging_integration_guide.md).
 
 ## Pagination
-Pagination is available on routes when explicitly set. There are a subset of routes available as part of this engine. Pagination is available to be used in downstream services as well. For more info, check out [Pagination ReadMe](docs/pagination.md)
+
+Pagination helpers are available for controllers and services. See [Pagination](docs/pagination.md).
+
+## Services
+
+`CommandTower::ServiceBase` adds logging and argument validation for **service** classes under workflows. See [ServiceBase](app/services/command_tower/README.md).
 
 ## License
-The engine is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+MIT — see [MIT-LICENSE](MIT-LICENSE).

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,438 @@
+# CommandTower API Reference
+
+Canonical **HTTP endpoint catalog** for the CommandTower engine. Paths are engine-relative — prefix with your host mount (for example `/api`).
+
+Health checks are **host-owned**. The engine does not expose a health route.
+
+Install / configure / migrate / doctor: [initializing.md](initializing.md). Extending: [extending.md](extending.md). Route area index: [controllers.md](controllers.md). Messaging emit (non-HTTP): [messaging_integration_guide.md](messaging_integration_guide.md).
+
+Proof for contracts lives primarily under `spec/requests/command_tower/`.
+
+## Table of Contents
+
+1. [Shared conventions](#shared-conventions)
+2. [Authentication mechanisms](#authentication-mechanisms)
+3. [Auth endpoints](#auth-endpoints)
+4. [Me and profile](#me-and-profile)
+5. [Me Inbox](#me-inbox)
+6. [Preferences](#preferences)
+7. [Phone](#phone)
+8. [Pushover](#pushover)
+9. [Admin messaging](#admin-messaging)
+10. [Non-HTTP emit APIs](#non-http-emit-apis)
+11. [RBAC overview](#rbac-overview)
+12. [Feature gates](#feature-gates)
+
+---
+
+## Shared conventions
+
+### Response envelope
+
+Engine controllers render through `render_application_result` → `EnvelopeSerializer`.
+
+**Success**
+
+```json
+{
+  "data": {},
+  "meta": {},
+  "errors": []
+}
+```
+
+**Failure**
+
+```json
+{
+  "data": null,
+  "meta": {},
+  "errors": [
+    { "code": "string", "message": "string", "details": {} }
+  ]
+}
+```
+
+- `meta` defaults to `{}` when omitted.
+- Each error always has `code` and `message`. `details` appears only when present.
+- Deserializer failures typically return **422** with `validation_failed` (and `details.failures` when applicable).
+
+This envelope is the contract for **CommandTower engine HTTP** endpoints. Host product controllers may use other shapes. Provisional host helpers (`authenticate_user!` / `authorize_user!`) can still fail via older `Schema::Error` renders — see [authentication_authorization_guide.md](authentication_authorization_guide.md).
+
+### Field casing
+
+Response bodies use **camelCase** keys from serializers (`firstName`, `tokenExpiresAt`, `totalCount`, …).
+
+Many deserializers accept both camelCase and snake_case aliases for inputs. Where only one form is accepted, it is noted per endpoint.
+
+### Content type
+
+Use `Content-Type: application/json` for JSON bodies. Responses are `application/json`.
+
+---
+
+## Authentication mechanisms
+
+| Mechanism | How |
+|-----------|-----|
+| Bearer JWT (default) | `Authorization: Bearer <token>` |
+| Cookie JWT (optional) | HttpOnly cookie when `config.jwt.cookie.enabled` — see [cookie_authentication_guide.md](cookie_authentication_guide.md) |
+| Signup session | `Authorization: Signup <token>` |
+| Password recovery session | `Authorization: Recovery <token>` |
+
+**Engine controllers** use `AuthenticationBoundary` / `AuthorizationBoundary` (`authenticate_request!` / `authorize_request!`). Failures return the envelope (`401` / `403` / `412` as applicable).
+
+**Token / cookie side effects** (login, logout, CSRF) are applied via `response_effects` on the workflow result (for example `X-Authorization-Expire`, Set-Cookie). See cookie guide for CORS and CSRF.
+
+Default JWT TTL is **7 days** (`config.jwt.ttl`).
+
+---
+
+## Auth endpoints
+
+### `POST /auth/register`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Gate** | Always drawn |
+| **Body** | `first_name`, `last_name`, `username`, `email`, `password`, `password_confirmation` (snake_case) |
+| **Success** | **201** — `data`: `{ user, message }` where `message` is `"Account created successfully"`. No token. |
+| **Errors** | `422` `validation_failed` / `email_already_registered`; `429` `signup_ip_rate_limited` |
+| **Spec** | `spec/requests/command_tower/auth/register_spec.rb` |
+
+`user` fields: `id`, `email`, `username`, `firstName`, `lastName`, `emailValidated`, `roles`.
+
+### `POST /auth/plain-text/login`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Gate** | `config.login.plain_text.enable?` (else route absent → **404**) |
+| **Body** | `identifier`, `password` (snake_case) |
+| **Success** | **201** — `data`: `{ user, token, tokenExpiresAt }` |
+| **Errors** | `401` `invalid_credentials` |
+| **Spec** | `spec/requests/command_tower/auth/plain_text/login_spec.rb` |
+
+### `POST /auth/logout`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Body** | none |
+| **Success** | **200** — `data`: `{ message: "logged_out" }` (clears auth cookie when cookie mode is enabled) |
+| **Spec** | `spec/requests/command_tower/auth/logout_spec.rb` |
+
+### `GET /auth/session`
+
+| | |
+|--|--|
+| **Auth** | `authenticate_request!` + `authorize_request!` |
+| **Success** | **200** — `data`: `{ user, tokenExpiresAt }` |
+| **Errors** | `401`; `403`; `412` `email_verification_required` when email verification gate applies |
+| **Spec** | `spec/requests/command_tower/auth/session_spec.rb` |
+
+### `POST /auth/signup-session`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Body** | none |
+| **Success** | **201** — `data`: `{ signupSessionToken, expiresAt }` (ISO8601) |
+| **Errors** | `429` `signup_ip_rate_limited` |
+| **Spec** | `spec/requests/command_tower/auth/signup_session_spec.rb` |
+
+### `GET /auth/identity-policy`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Success** | **200** — `data`: password / email / username / verificationCode / phoneVerificationCode policy objects (`minLength`, `maxLength`, `pattern`, …) |
+| **Spec** | `spec/requests/command_tower/auth/identity_policy_spec.rb` |
+
+### `GET /auth/email/availability`
+
+| | |
+|--|--|
+| **Auth** | Signup session (`Authorization: Signup …`) |
+| **Gate** | `config.signup_session.email_availability?` |
+| **Query** | `email` (required) |
+| **Success** | **200** — `data`: `{ valid, available, message }` |
+| **Errors** | `401` `signup_session_missing` / `signup_session_invalid` / `signup_session_expired`; `422`; `429` |
+| **Spec** | `spec/requests/command_tower/auth/email_availability_spec.rb` |
+
+### `GET /auth/username/availability`
+
+| | |
+|--|--|
+| **Auth** | Signup session |
+| **Gate** | `config.username.realtime_username_check?` |
+| **Query** | `username` (required) |
+| **Success** | **200** — `data`: `{ valid, available, message }` |
+| **Errors** | Same signup-session family as email availability |
+| **Spec** | `spec/requests/command_tower/auth/username_availability_spec.rb` |
+
+### `POST /auth/email-verification/send`
+
+| | |
+|--|--|
+| **Auth** | `authenticate_request!(bypass_email_validation: true)` + authorize |
+| **Gate** | `config.login.plain_text.email_verify?` |
+| **Body** | none |
+| **Success** | **201** when sent / **200** when already verified — `data`: `{ message }` |
+| **Errors** | `401`/`403`; `502` `verification_send_failed` |
+| **Spec** | `spec/requests/command_tower/auth/email_verification_spec.rb` |
+
+### `POST /auth/email-verification/verify`
+
+| | |
+|--|--|
+| **Auth** | Same as send (bypass email validation) |
+| **Gate** | Same |
+| **Body** | `code` |
+| **Success** | **201** `"Successfully verified email"` / **200** already verified — `data`: `{ message }` |
+| **Errors** | `422` `verification_code_invalid` |
+| **Spec** | `spec/requests/command_tower/auth/email_verification_spec.rb` |
+
+Workflow detail: [email_verification_workflow.md](email_verification_workflow.md).
+
+### `POST /auth/password-recovery-session`
+
+| | |
+|--|--|
+| **Auth** | Public (always drawn; not gated by password_reset) |
+| **Success** | **201** — `data`: `{ recoverySessionToken, expiresAt }` |
+| **Errors** | `429` `password_recovery_ip_rate_limited` |
+| **Spec** | `spec/requests/command_tower/auth/password_recovery_session_spec.rb` |
+
+### `POST /auth/password-reset/send`
+
+| | |
+|--|--|
+| **Auth** | Password recovery session (`Authorization: Recovery …`) |
+| **Gate** | `config.login.plain_text.password_reset?` |
+| **Body** | `email` |
+| **Success** | **200** — generic message (does not reveal whether the account exists) |
+| **Errors** | `401` `password_recovery_session_*`; `422`; `429`; `503` `password_reset_unavailable` |
+| **Specs** | `password_reset_send_spec.rb`, `password_reset_cross_token_spec.rb` |
+
+### `POST /auth/password-reset/validate`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Gate** | `password_reset?` |
+| **Body** | `token` (required); `email` optional unless config requires it |
+| **Success** | **200** — `data`: `{ valid: true, expiresAt? }` |
+| **Errors** | `401` `password_reset_invalid_token`; `422` |
+| **Spec** | `spec/requests/command_tower/auth/password_reset_validate_and_reset_spec.rb` |
+
+### `POST /auth/password-reset/reset`
+
+| | |
+|--|--|
+| **Auth** | Public |
+| **Gate** | `password_reset?` |
+| **Body** | `token`, `password`, `passwordConfirmation` or `password_confirmation`; optional `email` |
+| **Success** | **200** — `data`: `{ message: "Password has been successfully reset" }` |
+| **Errors** | `401` `password_reset_invalid_token`; `422` |
+| **Spec** | `spec/requests/command_tower/auth/password_reset_validate_and_reset_spec.rb` |
+
+Workflow detail: [password_reset_workflow.md](password_reset_workflow.md).
+
+---
+
+## Me and profile
+
+### `GET /me`
+
+| | |
+|--|--|
+| **Auth** | authenticate + authorize |
+| **Success** | **200** — account payload including `id`, `firstName`, `lastName`, `fullName`, `username`, `email`, `emailValidated`, `phoneNumber`, `phoneNumberValidated`, `roles`, `createdAt`, `capabilities` |
+| **Spec** | `spec/requests/command_tower/me_spec.rb` |
+
+`capabilities` keys (each `{ enabled: boolean }`): `editName`, `editUsername`, `changeEmail`, `changePassword`, `editPhone`, `editPushover`, `logoutAllDevices`, `verifyEmail`.
+
+### `GET /profile`
+
+| | |
+|--|--|
+| **Auth** | authenticate + authorize |
+| **Success** | **200** — UserSerializer only (`id`, `email`, `username`, `firstName`, `lastName`, `emailValidated`, `roles`) |
+| **Spec** | `spec/requests/command_tower/profile_spec.rb` |
+
+### `PATCH /me/name`
+
+| | |
+|--|--|
+| **Auth** | authenticate + authorize |
+| **Body** | `firstName`/`first_name`, `lastName`/`last_name` |
+| **Success** | **200** — AccountSerializer (same shape family as `GET /me`) |
+| **Errors** | `422` `validation_failed` |
+| **Spec** | `spec/requests/command_tower/me/name_spec.rb` |
+
+Name-only. There is no engine HTTP for email/username self-modify or verifier rotation except via password change (and host ops).
+
+### `PATCH /me/password`
+
+| | |
+|--|--|
+| **Auth** | authenticate + authorize |
+| **Body** | `currentPassword`/`current_password`, `password`, `passwordConfirmation`/`password_confirmation` |
+| **Success** | **200** — `data`: `{ message: "Password updated successfully." }` |
+| **Errors** | `422` validation / wrong current password |
+| **Spec** | `spec/requests/command_tower/me/password_spec.rb` |
+
+Rotates `verifier_token` (invalidates outstanding sessions). See [change_password_workflow.md](change_password_workflow.md) and [sensitive_routes.md](sensitive_routes.md).
+
+---
+
+## Me Inbox
+
+All inbox routes: authenticate + authorize. Host must map RBAC entities for inbox controller actions (see dummy host `rails_app/config/rbac_groups.yml`).
+
+Pagination for list: query `limit` (default **50**, max **100**), `offset` (default **0**), `scope` (`inbox` \| `archived`, default `inbox`). List `meta`: `{ limit, offset, totalCount }`. See [pagination.md](pagination.md).
+
+| Method | Path | Notes |
+|--------|------|--------|
+| `GET` | `/me/inbox` | List — `data` array of items; pagination meta |
+| `GET` | `/me/inbox/:id` | Detail (+ `body`, `metadata`, `notificationTypeKey`) |
+| `POST` | `/me/inbox/:id/open` | Detail |
+| `PATCH` | `/me/inbox/:id/archive` | Item |
+| `DELETE` | `/me/inbox/:id` | `data: null` |
+| `GET` | `/me/inbox/unread-count` | `{ count }` |
+| `POST` | `/me/inbox/bulk/read` | Body `ids` (1–100 ints) → `{ ids, count, changedCount }` |
+| `POST` | `/me/inbox/bulk/unread` | same |
+| `POST` | `/me/inbox/bulk/archive` | same |
+| `POST` | `/me/inbox/bulk/restore` | same |
+| `POST` | `/me/inbox/bulk/delete` | same |
+
+**List item fields:** `id`, `title`, `status`, `read`, `viewedAt`, `createdAt`, `updatedAt`.
+
+**Errors:** `401` / `403` / `422`; show/open may return `404` `not_found`.
+
+**Specs:** `spec/requests/command_tower/me/inbox_spec.rb`, `me/inbox_bulk_spec.rb`.
+
+---
+
+## Preferences
+
+| | Show | Update |
+|--|------|--------|
+| **Path** | `GET /me/preferences` | `PATCH /me/preferences/:notification_type_key` |
+| **Auth** | authenticate + authorize | same |
+| **Body** | none | `preferences: { inboxEnabled?, channels?: { <channelKey>: bool } }` (preference keys camelCase; unknown keys rejected) |
+| **Success** | `data`: `{ categories: [...] }` | `data`: `{ notification: ... }` |
+| **Errors** | `401`/`403`; update `404` unknown type; `422` invalid prefs |
+| **Spec** | `spec/requests/command_tower/me/preferences_spec.rb` | |
+
+Category / notification serializers expose catalog fields (`key`, `label`, `description`, `order`, channel availability, `preferences: { inboxEnabled, channels, storedOverridePresent }`, …).
+
+---
+
+## Phone
+
+Routes are **always drawn**. Product SMS readiness is workflow-gated as **503** `sms_capability_unavailable`.
+
+| Method | Path | Body | Success | Spec |
+|--------|------|------|---------|------|
+| `PATCH` | `/me/phone` | `phoneNumber`/`phone_number` | AccountSerializer | `me/phone_spec.rb` |
+| `DELETE` | `/me/phone` | — | AccountSerializer | same |
+| `POST` | `/me/phone/verification` | — | `{ codeLength, expiresAt, resendAvailableAt?, phoneNumber }` | `me/phone_verification_spec.rb` |
+| `POST` | `/me/phone/verification/verify` | `code` (or nested `phone_verification.code`) | AccountSerializer | same |
+
+Other errors include `422` (`phone_missing`, `phone_verification_code_invalid`, …), `429` `phone_verification_throttled` (meta may include `resendAvailableAt`), `502` `phone_verification_send_failed`.
+
+---
+
+## Pushover
+
+Routes are **always drawn**. Product readiness is workflow-gated as **503** `pushover_capability_unavailable`.
+
+| Method | Path | Body | Notes |
+|--------|------|------|--------|
+| `GET` | `/me/pushover` | — | Configured or unconfigured view |
+| `POST` | `/me/pushover` | `userKey`/`user_key`, `applicationToken`/`application_token` | Create |
+| `PATCH` / `PUT` | `/me/pushover` | same | Replace |
+| `DELETE` | `/me/pushover` | — | Unconfigured view |
+| `POST` | `/me/pushover/verification` | — | Verify configured credentials |
+
+**Configured fields include:** `configured`, `id`, `channelKey`, `lifecycleState`, `verificationState`, `maskedDisplayValue`, `credentialsConfigured`, `verifiedAt`, `createdAt`, `updatedAt`, `actions: { canCreate, canVerify, canReplace, canRemove }`.
+
+**Spec:** `spec/requests/command_tower/me/pushover_spec.rb`.
+
+Errors include `422` (`pushover_already_configured`, `pushover_not_configured`, …), `502` `pushover_provider_unavailable`, `503`.
+
+---
+
+## Admin messaging
+
+### `POST /admin/messaging/announcements`
+
+| | |
+|--|--|
+| **Auth** | authenticate + authorize (RBAC entity `admin_messaging_announcements`) |
+| **Success** | **202** |
+| **Spec** | `spec/requests/command_tower/admin/messaging/announcements_spec.rb` |
+
+**Body** (camel preferred; snake via underscore fallback): `title`, `body`, `campaignIdentity` (required), `audience` (`user_ids` \| `all_users`), `userIds` (required when `user_ids`), `notificationTypeKey` (default `"promotional_announcement"`), `executionMode` (`async` \| `sync`, default `async`), `metadata` (optional).
+
+**Async response:** `mode`, `requested`, `campaignIdentity`, `enqueued`, `enqueueFailed`.
+
+**Sync response:** `mode`, `requested`, `campaignIdentity`, `accepted`, `failed`, `skipped`, `failures: [{ userId, errorCode }]`.
+
+Engine admin HTTP is **announcements only**. There is no `/admin` user list, modify, role assign, or impersonate surface.
+
+---
+
+## Non-HTTP emit APIs
+
+Hosts call these from **product workflows** (not as HTTP on the engine):
+
+| Service | Required kwargs |
+|---------|-----------------|
+| `CommandTower::Services::Messaging::Communications::Produce` | `user`, `notification_type_key`, `host_event_identity`, `title`, `body`, `platform_enabled_channels`; optional `metadata` |
+| `CommandTower::Services::Messaging::Communications::ProduceMany` | `user_ids`, `notification_type_key`, `campaign_identity`, `title`, `body`, `platform_enabled_channels`; optional `metadata`, `execution_mode` (`:async` default, `:sync` capped at 25) |
+
+Details: [messaging_integration_guide.md](messaging_integration_guide.md).
+
+---
+
+## RBAC overview
+
+Engine defaults (`lib/command_tower/authorization/default.yml`):
+
+- Group `owner` — all entities
+- Group `admin` — entity `admin_messaging_announcements` on `AnnouncementsController#create`
+
+Hosts **must** supply `rbac_groups.yml` entities for Me / Auth / session surfaces (fail-closed). The dummy host file `rails_app/config/rbac_groups.yml` shows a `member` mapping pattern.
+
+Configure via `CommandTower.configure { |c| c.authorization.rbac_group_path = ... }`. Deep guide: [authentication_authorization_guide.md](authentication_authorization_guide.md). Quick start: [authorization.md](authorization.md).
+
+---
+
+## Feature gates
+
+When a gate is off, the route is **not drawn** → **404**.
+
+| Routes | Config |
+|--------|--------|
+| `POST /auth/plain-text/login` | `login.plain_text.enable?` |
+| `GET /auth/email/availability` | `signup_session.email_availability?` |
+| `GET /auth/username/availability` | `username.realtime_username_check?` |
+| Email verification send/verify | `login.plain_text.email_verify?` |
+| Password reset send/validate/reset | `login.plain_text.password_reset?` |
+
+Always drawn (not route-gated): register, logout, session, signup-session, identity-policy, password-recovery-session, Me/profile/inbox/preferences/phone/pushover, admin announcements. Phone/Pushover use **503** capability errors when product adapters are unavailable.
+
+---
+
+## Related
+
+- [Authentication](authentication.md) / [Authorization](authorization.md)
+- [Cookie authentication](cookie_authentication_guide.md)
+- [Sensitive changes](sensitive_routes.md)
+- [Pagination](pagination.md)
+- [Messaging](messaging_integration_guide.md)
+- [README](../README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,30 @@
+# CommandTower Architecture (host-facing)
+
+CommandTower is a mountable Rails engine. Host applications consume platform capabilities through engine HTTP, configuration, and shared factories. Product behavior stays in the host.
+
+## Layer map
+
+```text
+Controller / Job → Workflow → Shared Sequences / Services → Models & Clients
+```
+
+| Layer | Owns | Does not own |
+|-------|------|--------------|
+| Controller | Transport, auth preconditions, deserialization, **one** workflow, envelope render | Business rules, persistence, external I/O |
+| Workflow | Orchestration of one business action | Capability implementation details |
+| Shared sequence | Reusable orchestration fragments | External entry points |
+| Service | One business capability (`ServiceBase` / ApplicationService) | Workflows, transport |
+| Model | Persistence and data validation | Orchestration, external I/O |
+| Client | External system I/O | Business orchestration |
+
+**Hard rule:** meaningful business behavior enters through a workflow—never directly from a controller into a service for a full business action.
+
+## Where to read more
+
+- Long-form rationale (workspace): `artifacts/rails_architecture_handbook.md`
+- Condensed enforcement (workspace): `.cursor/rules/rails-architecture.mdc`
+- Service capability base: [ServiceBase README](../app/services/command_tower/README.md)
+- Install and host ownership: [Initializing](initializing.md)
+- Host extension boundaries: [Extending](extending.md)
+
+Back to [README](../README.md).

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,51 +1,37 @@
 # Authentication
 
-Authentication is backed by JWT tokens. There are many options to the JWT configuration. Check out [Initializing](initializing.md) to understand where to find the config.
+Authentication establishes **who** is calling. Failed authentication returns `401`.
 
-## Usage
-Authenticating a User is straightforward via Rails actions. In each controller that you want to authenticate, add the following
+## Engine controllers
+
+Modern engine controllers use the authentication boundary:
+
+```ruby
+# via AuthenticationBoundary
+before_action :authenticate_request!
+```
+
+Token extraction checks `Authorization: Bearer {token}` first, then an HttpOnly cookie when cookie auth is enabled. Failures use the application envelope (`{ data, meta, errors }`).
+
+## Host controllers (provisional)
+
 ```ruby
 before_action :authenticate_user!
+# current_user is set when authentication succeeds
 ```
 
-This action will authenticate the user and set `current_user` to the user passed in via the JWT token.
+Failure JSON may still use older `Schema::Error` shapes — not identical to the engine envelope. See the deep guide.
 
-Every API request will return a header that indicates when the current token will expire:
-```
-X-Authentication-Expire="2025-01-16 04:36:29 +0000"
-```
+Configure secrets and JWT options during install — see [Initializing](initializing.md).
 
-### Header Token
-For routes that expect user authentication, the client must set the Header value:
-```
-Authentication="Bearer: {token value}"
-```
+## Where to go next
 
-### How to get the JWT Token
-Each Authentication strategy has a `/login` route. This route will return to you a valid token that can then be used for subsequent API Calls
+| Need | Guide |
+|------|-------|
+| Full authn + RBAC design | [Authentication & authorization guide](authentication_authorization_guide.md) |
+| Cookie / CORS / CSRF | [Cookie authentication](cookie_authentication_guide.md) |
+| HTTP contracts | [API reference](api_reference.md) |
+| Session invalidation | [Sensitive changes](sensitive_routes.md) |
+| Authorization (RBAC) | [Authorization](authorization.md) |
 
-### Regenerate JWT token on the fly
-The token can be refreshed in any API call when provided an existing JWT token. To refresh the token, simply add the following Header value to a request:
-
-```
-X-Authentication-Reset=true
-```
-
-The request will return the following header:
-```
-X-Authentication-Reset="Regenerated token"
-```
-
-**Use Caution** when regenerating the JWT token. While nothing is stopping you from regenerating on every request, it will add some latency that is may not be needed.
-
-## Encryption
-JWT tokens are encrypted at rest. The Encryption key is delivered as the `hmac_secret` in the configuration or set as an ENV variable `SECRET_KEY_BASE`.
-
-## Default JWT Payload's
-JWT can hold a payload. This payload is encrypted and is sent as part of the encrypted header
-
-### Expires At
-The `expires_at` payload is a timestamp for when the token must be regenerated. After the token "expires", the User will no longer be authenticated to actions and a `401` is returned.
-
-### Verifier Token
-Each user has a `verifier_token` encrypted into the payload of the JWT token. This token must match what is on the User's Record. If it does not match, a 403 is returned. A User or and Admin can reset the versifier token any time they want to log out of all sessions.
+Back to [README](../README.md).

--- a/docs/authentication_authorization_guide.md
+++ b/docs/authentication_authorization_guide.md
@@ -1,0 +1,150 @@
+# Authentication & Authorization Guide
+
+Deep guide for JWT authn, session boundaries, RBAC, and how Engine vs host helpers differ.
+
+Quick starts: [authentication.md](authentication.md), [authorization.md](authorization.md). HTTP catalog: [api_reference.md](api_reference.md). Cookies: [cookie_authentication_guide.md](cookie_authentication_guide.md).
+
+## Authn vs authz
+
+| Concern | Meaning | Typical failure |
+|---------|---------|-----------------|
+| **Authentication** | Who is calling | `401` |
+| **Authorization** | Are they allowed to perform this action | `403` |
+
+Keep them separate. Authenticate first; authorize after `current_user` is established.
+
+## Engine HTTP boundaries
+
+Modern engine controllers use concerns:
+
+- `CommandTower::Auth::AuthenticationBoundary` → `authenticate_request!`
+- `CommandTower::Auth::AuthorizationBoundary` → `authorize_request!`
+
+Failures render the application **envelope** (`{ data, meta, errors }`) via `render_application_result`.
+
+Email verification controllers call `authenticate_request!(bypass_email_validation: true)` so unverified users can complete verification.
+
+### Host provisional helpers
+
+`CommandTower::ApplicationController` still exposes:
+
+```ruby
+before_action :authenticate_user!
+before_action :authorize_user!
+```
+
+Hosts may use these on host controllers. Failure shapes can still use older `Schema::Error::*` JSON — **not** identical to the engine envelope. Prefer aligning new host JSON APIs to the envelope yourself, or call into workflows that return `WorkflowResult`.
+
+## Token transport
+
+1. **Bearer** — `Authorization: Bearer <jwt>` (primary)
+2. **Cookie** — optional HttpOnly JWT when `config.jwt.cookie.enabled` (see cookie guide)
+3. **Signup session** — `Authorization: Signup <token>` for availability checks
+4. **Password recovery session** — `Authorization: Recovery <token>` for password-reset send
+
+Default JWT TTL: **7 days** (`config.jwt.ttl`).
+
+### Verifier token
+
+JWTs embed a `verifier_token` claim bound to `User#verifier_token`. Rotation invalidates outstanding tokens. See [sensitive_routes.md](sensitive_routes.md).
+
+Authenticated password change (`PATCH /me/password`) rotates the verifier. Browser `POST /auth/logout` clears cookie transport only.
+
+## Primary auth HTTP flows
+
+Paths are engine-relative. Full request/response shapes: [api_reference.md](api_reference.md).
+
+| Flow | Endpoints |
+|------|-----------|
+| Register | `POST /auth/register` |
+| Login | `POST /auth/plain-text/login` (gate: `login.plain_text.enable?`) |
+| Session | `GET /auth/session` |
+| Logout | `POST /auth/logout` |
+| Current account | `GET /me`, `GET /profile` |
+| Name | `PATCH /me/name` |
+| Password change | `PATCH /me/password` |
+| Identity policy | `GET /auth/identity-policy` |
+| Signup session | `POST /auth/signup-session` → availability GETs |
+| Email verification | `POST /auth/email-verification/{send,verify}` |
+| Password recovery | `POST /auth/password-recovery-session` → `POST /auth/password-reset/{send,validate,reset}` |
+
+There is **no** `GET /user`, `POST /user/modify`, `POST /auth/login` (without `plain-text`), or `POST /auth/password/change` on the modern engine.
+
+## Session boundaries
+
+### Signup session
+
+1. `POST /auth/signup-session` → `signupSessionToken`
+2. Call gated availability endpoints with `Authorization: Signup …`
+
+Used by email/username availability. Missing/invalid/expired session → `401` with `signup_session_*` codes.
+
+### Password recovery session
+
+1. `POST /auth/password-recovery-session` → `recoverySessionToken`
+2. `POST /auth/password-reset/send` requires `Authorization: Recovery …`
+
+Validate/reset use the emailed reset token in the body (public). See [password_reset_workflow.md](password_reset_workflow.md).
+
+## RBAC
+
+### Engine defaults
+
+`lib/command_tower/authorization/default.yml`:
+
+- **`owner`** — `entities: true` (full access)
+- **`admin`** — entity `admin_messaging_announcements` on `Admin::Messaging::AnnouncementsController#create`
+
+There are no engine default roles named `admin-read-only`, `admin-without-impersonation`, or impersonation APIs.
+
+### Host RBAC file (required for Me/Auth)
+
+`AuthorizeRequest` fails closed when controller actions lack entity mappings. Hosts must supply RBAC YAML (default path `config/rbac_groups.yml`):
+
+```ruby
+CommandTower.configure do |c|
+  c.authorization.rbac_group_path = Rails.root.join("config/rbac_groups.yml")
+end
+```
+
+Dummy host example: `rails_app/config/rbac_groups.yml` — defines a **`member`** group and entities for session, me, profile, inbox, preferences, phone, pushover, email verification. Do not redefine groups that already exist in `default.yml` (for example `admin`); add entities and attach them carefully.
+
+Admin announcements: assign users the `admin` role (or another role that includes `admin_messaging_announcements`).
+
+### Host controller recipe
+
+```ruby
+class Host::ThingsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authorize_user!
+
+  def show
+    # Prefer one workflow + envelope-compatible render for new APIs
+  end
+end
+```
+
+Map host controllers to RBAC entities the same way engine controllers are mapped in the dummy host file.
+
+## Engine admin HTTP
+
+Only:
+
+```http
+POST /admin/messaging/announcements
+```
+
+No SchemaHelper admin user list, attribute modify, role assign, or impersonate routes. User administration is host/ops (`command_tower:users:create`, host tooling, etc.).
+
+## Email verification gate
+
+When email verification is required, authenticated requests may receive **412** `email_verification_required` until verified. Verification endpoints bypass that gate. See [email_verification_workflow.md](email_verification_workflow.md).
+
+## Related
+
+- [API reference](api_reference.md)
+- [Cookie authentication](cookie_authentication_guide.md)
+- [Sensitive changes](sensitive_routes.md)
+- [Initializing](initializing.md)
+- [Messaging](messaging_integration_guide.md)
+- [README](../README.md)

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -1,34 +1,34 @@
-# Authorization via RBAC
+# Authorization (RBAC)
 
-Some users will have different permissions than others. RBAC based permissions can be route specific or controller specific.
+Authorization establishes **permission** after authentication. Failed authorization returns `403`.
 
-## Integrate Authorization
-Authorization requires routes that have a `current_user` defined. Current User is defined by default via [Authentication](authentication.md) but you can also define it yourself.
+Host `rbac_groups.yml` is a **required integration step** (Step 4) — see [Host integration](host_integration_guide.md#step-4--host-rbac-required). Without it, authenticated Me/Auth calls fail closed.
 
-After defining the role, set the before_action
+## Quick usage (host provisional)
+
 ```ruby
-# Order is important here
-# authorize_user! depends on current_user being defined via authentication
+# Order matters: authorize depends on current_user from authentication
 before_action :authenticate_user!
 before_action :authorize_user!
 ```
 
-## Default roles
-Default roles are statically defined in [lib/command_tower/authorization/default.yml](../lib/command_tower/authorization/default.yml).
+Engine controllers use `authorize_request!` instead (AuthorizationBoundary) and return the application envelope on failure.
 
-Roles include:
-- `owner`: Users defined as owner will have access to every route regardless of required roles
-- `admin`: Users defined as admin will have full access to all actions on the `AdminController`. This includes the ability to change settings on other users and impersonate other users
-- `admin-without-impersonation`: Users defined with this role can hit all AdminController actions except `impersonate`
-- `admin-read-only`: Users defined with this role can only hit the index page for viewing existing users and their settings.
+## Roles and host mapping
 
+Engine defaults in `lib/command_tower/authorization/default.yml`:
 
-## Creating new Roles
+- `owner` — full access (`entities: true`)
+- `admin` — `admin_messaging_announcements` only
 
-### From Config File
-Additional roles can be defined via a separate yml file that you can define from the [Initializer Config option](initializing.md) `CommandTower.config.authorization.rbac_group_path` (By default we will look in `config/rbac_groups.yml`)
+Hosts **must** map Me/Auth controller actions in host YAML (`CommandTower.config.authorization.rbac_group_path`, default `config/rbac_groups.yml`) or authorization fails closed. See dummy host `rails_app/config/rbac_groups.yml` (`member` entities).
 
-### From Code File
-Defining code files is only recommended if you require complex user authorization. For more details check out the Spec tests
-[/spec/lib/command_tower/authorization/role_spec.rb](/spec/lib/command_tower/authorization/role_spec.rb) (`with custom authorized entity`)
+## Where to go next
 
+| Need | Guide |
+|------|-------|
+| Full RBAC entities, roles, failure shapes | [Authentication & authorization guide](authentication_authorization_guide.md) |
+| Authentication | [Authentication](authentication.md) |
+| Install / config | [Initializing](initializing.md) |
+
+Back to [README](../README.md).

--- a/docs/change_password_workflow.md
+++ b/docs/change_password_workflow.md
@@ -1,0 +1,67 @@
+# Authenticated Password Change Workflow
+
+Authenticated password change lets a signed-in user replace their password by proving knowledge of the current password. On success, CommandTower rotates `verifier_token` in the same transaction as the password digest update, invalidating **all** existing JWT sessions (including the caller’s). The API does **not** re-issue a JWT; hosts must clear local auth and send the user through Sign In again.
+
+This is distinct from [password recovery](password_reset_workflow.md), which is public and recovery-session/token-based.
+
+## Purpose and orchestration
+
+| Item | Value |
+|------|--------|
+| Route | `PATCH /me/password` (engine-relative) |
+| Auth | Authentication + authorization boundaries |
+| Controller | `CommandTower::Me::PasswordController#update` |
+| Workflow | `CommandTower::Workflows::Me::ChangePasswordWorkflow` (`ApplicationWorkflow`, `retry_strategy :none`) |
+| Service | `CommandTower::Services::Me::ChangePassword` |
+| Deserializer | `CommandTower::Deserializers::Me::ChangePasswordDeserializer` |
+| Serializer | `CommandTower::Serializers::Me::ChangePasswordResponseSerializer` |
+| Feature gate | Route always drawn (not constrained in `routes.rb`) |
+
+**Boundary:** The controller deserializes input and runs **one** workflow. The workflow orchestrates the change-password service and maps failures to HTTP status. It does not implement password rules itself.
+
+## Request
+
+```json
+{
+  "current_password": "string",
+  "password": "string",
+  "password_confirmation": "string"
+}
+```
+
+## Success (200)
+
+Serialized success payload (message only). Response effects include `clear_token: true` so cookie/header sessions are cleared. No JWT, verifier, or password material is returned.
+
+## Service flow (under the workflow)
+
+1. Authenticate `current_password`
+2. Confirm `password` matches `password_confirmation`
+3. Enforce configured password length bounds
+4. In one DB transaction: persist new password digest → `reset_verifier_token!`
+5. On failure: typed application errors → workflow HTTP mapping
+
+## Failures
+
+| Condition | Typical status |
+|-----------|----------------|
+| Missing / invalid JWT | 401 |
+| Validation / bad current password / confirmation | 4xx via Me error mapping |
+| Unexpected infra failure | 5xx |
+
+## Contrast with recovery reset
+
+| | Authenticated change | Forgot / reset |
+|--|----------------------|----------------|
+| Proof | Current password | Recovery session + reset token |
+| Route | `PATCH /me/password` | `POST /auth/password-recovery-session` + `/auth/password-reset/*` |
+| Auth | JWT | Public (+ recovery session) |
+| Verifier | Rotated | See recovery guide |
+| Post-success | All JWTs invalid; host → Sign In | Host-defined |
+
+## Related
+
+- [Sensitive changes](sensitive_routes.md)
+- [API reference](api_reference.md)
+- [Password reset workflow](password_reset_workflow.md)
+- [Extending](extending.md)

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -1,0 +1,35 @@
+# Controllers and routes
+
+CommandTower exposes platform HTTP through `CommandTower::Engine` routes. Hosts typically mount the engine (for example at `/api`) via the configure generator or a custom mount.
+
+This page is an **index** of route areas. Detailed request/response contracts live in the [API reference](api_reference.md).
+
+## Route areas
+
+| Area | Prefix (engine-relative) | Purpose |
+|------|--------------------------|---------|
+| Auth session | `/auth/*` | Login, logout, session, register, signup-session, identity policy, availability |
+| Email verification | `/auth/email-verification/*` | Send / verify email codes |
+| Password recovery | `/auth/password-recovery-session`, `/auth/password-reset/*` | Forgot / reset password |
+| Me / profile | `/me`, `/profile`, `/me/name`, `/me/password` | Account reads and updates |
+| Inbox | `/me/inbox*` | User inbox consume (list, open, archive, bulk ops) |
+| Preferences | `/me/preferences*` | Notification preferences |
+| Phone | `/me/phone*` | Phone endpoint + verification |
+| Pushover | `/me/pushover*` | Pushover endpoint lifecycle + verification |
+| Admin messaging | `/admin/messaging/announcements` | Cohort announcements |
+
+Exact paths depend on where the host mounts the engine.
+
+## Controllers
+
+Engine controllers are transport adapters: authenticate/authorize as required, deserialize, run **exactly one** workflow, render the application envelope. See [Architecture](architecture.md).
+
+## Related
+
+- [API reference](api_reference.md) — endpoint catalog
+- [Messaging](messaging_integration_guide.md) — messaging surfaces summary
+- [Extending](extending.md) — host extension boundaries
+- [Initializing](initializing.md) — mount and configure
+- [README](../README.md)
+
+HTTP request specs for the engine live under `spec/requests/`.

--- a/docs/cookie_authentication_guide.md
+++ b/docs/cookie_authentication_guide.md
@@ -1,0 +1,167 @@
+# Cookie Authentication Guide
+
+HttpOnly cookie authentication for browser / SPA hosts. Mobile and API clients typically use Bearer tokens only.
+
+Back to [README](../README.md). Endpoint contracts: [API reference](api_reference.md). Deep authn/RBAC: [authentication_authorization_guide.md](authentication_authorization_guide.md).
+
+Journey coverage: `spec/integration_test/auth/cookie_*.rb`.
+
+## Enable cookies
+
+```ruby
+CommandTower.configure do |config|
+  config.jwt.cookie.enabled = true
+  # Optional CSRF for cookie-authenticated unsafe methods:
+  # config.jwt.cookie.csrf.enabled = true
+end
+```
+
+### Defaults
+
+| Setting | Default |
+|---------|---------|
+| `jwt.ttl` | `7.days` |
+| `jwt.cookie.enabled` | `false` |
+| `jwt.cookie.name` | `"ct_jwt"` |
+| `jwt.cookie.same_site` | `:lax` |
+| `jwt.cookie.secure` | `false` (set `true` in production / HTTPS) |
+| `jwt.cookie.httponly` | `true` |
+| `jwt.cookie.path` | `"/"` |
+| `jwt.cookie.domain` | `nil` (host-only) |
+| `jwt.cookie.ttl` | `7.days` |
+| `jwt.cookie.csrf.enabled` | `false` |
+| `jwt.cookie.csrf.cookie_name` | `"ct_csrf"` |
+| `jwt.cookie.csrf.header_name` | `"X-CSRF-Token"` |
+| `jwt.cookie.csrf.rotate_on_login` | `true` |
+| `jwt.cookie.csrf.rotate_on_reset` | `true` |
+| CSRF `same_site` / `secure` / `path` / `domain` | `nil` (inherit JWT cookie) |
+| CSRF `ttl` | `7.days` |
+
+## Token extraction order
+
+1. `Authorization: Bearer <token>` header (wins when present)
+2. HttpOnly JWT cookie when cookie mode is enabled
+
+## Login / logout examples
+
+Paths are engine-relative. Prefix with your mount (generator often mounts at `/`; hosts may use `/api`).
+
+Plain-text login is gated by `config.login.plain_text.enable?`.
+
+### Login
+
+```http
+POST /auth/plain-text/login
+Content-Type: application/json
+
+{ "identifier": "user@example.com", "password": "secret" }
+```
+
+Success **201** envelope:
+
+```json
+{
+  "data": {
+    "user": {
+      "id": 1,
+      "email": "user@example.com",
+      "username": "user",
+      "firstName": "Ada",
+      "lastName": "Lovelace",
+      "emailValidated": true,
+      "roles": ["member"]
+    },
+    "token": "<jwt>",
+    "tokenExpiresAt": "<iso8601>"
+  },
+  "meta": {},
+  "errors": []
+}
+```
+
+When cookies are enabled, the response also sets the JWT cookie (and may set/rotate CSRF cookie). Clients that rely on cookies should use `credentials: "include"` (fetch) / `withCredentials: true` (axios).
+
+### Current user
+
+```http
+GET /me
+Authorization: Bearer <jwt>
+```
+
+Or rely on the JWT cookie when cookie mode is enabled and no Bearer header is sent.
+
+### Logout (this browser)
+
+```http
+POST /auth/logout
+```
+
+Success **200**:
+
+```json
+{
+  "data": { "message": "logged_out" },
+  "meta": {},
+  "errors": []
+}
+```
+
+Clears the auth cookie for this client. It does **not** rotate `verifier_token`, so other devices’ JWTs remain valid until expiry or verifier rotation.
+
+### Logout everywhere
+
+Rotate the verifier via authenticated password change:
+
+```http
+PATCH /me/password
+```
+
+Or call `user.reset_verifier_token!` from trusted host ops. There is no `POST /user/modify` engine route.
+
+See [sensitive_routes.md](sensitive_routes.md).
+
+## CSRF (optional)
+
+When `jwt.cookie.csrf.enabled` is true, cookie-authenticated **unsafe** methods (POST/PATCH/PUT/DELETE) require:
+
+1. Non-HttpOnly CSRF cookie (`ct_csrf` by default)
+2. Matching header (`X-CSRF-Token` by default)
+
+Mismatch / missing → auth failure with codes such as `csrf_missing` / `csrf_mismatch` (envelope via modern auth boundaries).
+
+Bearer-header requests do not require CSRF.
+
+## CORS
+
+Browser SPA on another origin needs host CORS that allows credentials and your frontend origin. Example sketch (host-owned):
+
+```ruby
+# Host rack-cors or equivalent — illustrative only
+allow do
+  origins "https://app.example.com"
+  resource "*",
+    headers: :any,
+    methods: [:get, :post, :put, :patch, :delete, :options],
+    credentials: true,
+    expose: ["X-Authorization-Expire", "X-Authorization-Reset"]
+end
+```
+
+`SameSite=None` cookies require `Secure=true` (HTTPS). Prefer same-site deployments with `SameSite=Lax` when possible.
+
+## Production checklist
+
+- [ ] `jwt.cookie.enabled = true` only when browsers need cookies
+- [ ] `jwt.cookie.secure = true` on HTTPS
+- [ ] Review `same_site` for cross-site SPAs
+- [ ] Enable CSRF if cookies authenticate mutating requests from browsers
+- [ ] CORS credentials + explicit origin (not `*`)
+- [ ] Do not log tokens or CSRF secrets
+
+## Related
+
+- [API reference](api_reference.md)
+- [Authentication](authentication.md)
+- [Authentication & authorization guide](authentication_authorization_guide.md)
+- [Sensitive changes](sensitive_routes.md)
+- [Initializing](initializing.md)

--- a/docs/email_verification_workflow.md
+++ b/docs/email_verification_workflow.md
@@ -1,0 +1,58 @@
+# Email Verification Workflow
+
+Code-based email verification ensures the user can receive mail at their registered address. Users authenticate with JWT; a configurable grace period may allow API access before verification is mandatory.
+
+## Purpose and orchestration
+
+| Step | Route | Workflow |
+|------|-------|----------|
+| Send code | `POST /auth/email-verification/send` | `Workflows::Auth::EmailVerification::SendWorkflow` |
+| Verify code | `POST /auth/email-verification/verify` | `Workflows::Auth::EmailVerification::VerifyWorkflow` |
+
+Both workflows inherit `ApplicationWorkflow` with `retry_strategy :none`.
+
+| Item | Value |
+|------|--------|
+| Controllers | `CommandTower::Auth::EmailVerification::SendController` / `VerifyController` |
+| Auth | Authentication + authorization boundaries; send bypasses email-validation precondition so unverified users can request codes |
+| Feature gate | `CommandTower.config.login.plain_text.email_verify?` |
+
+**Boundary:** Controllers authenticate/authorize, run **one** workflow, render results. Workflows orchestrate verification services. Hosts do not reopen JWT or email-verification framework internals — see [extending.md](extending.md).
+
+## Key characteristics
+
+- **Method:** Numeric code (length configurable; commonly 6 digits)
+- **Delivery:** Email to the registered address
+- **Expiration:** Configurable (commonly ~10 minutes)
+- **Authentication required:** Valid JWT
+- **Grace period:** Configurable window before verification is enforced on other routes
+
+## Endpoints (engine-relative)
+
+### Send
+
+`POST /auth/email-verification/send`
+
+No body typically required (uses `current_user`). Returns a message payload on success.
+
+### Verify
+
+`POST /auth/email-verification/verify`
+
+**Body (typical):** `{ "code": "string" }`  
+
+On success, marks the user’s email validated.
+
+## Errors
+
+Standard application envelope. Invalid codes and validation failures map through Auth identity error status helpers. See [API reference](api_reference.md) for envelope shape.
+
+## Configuration
+
+Email verification options live on CommandTower config (enablement, code length, TTL, grace period). Hosts set secrets and product mail delivery via initializer — [initializing.md](initializing.md).
+
+## Related
+
+- [API reference](api_reference.md)
+- [Authentication](authentication.md)
+- [Extending](extending.md)

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,105 @@
+# Extending CommandTower
+
+How hosts customize and integrate with CommandTower **without forking platform internals**.
+
+**New host?** Start with [Host integration](host_integration_guide.md).
+
+Layer map: [architecture.md](architecture.md). Install/configure/migrate/doctor: [initializing.md](initializing.md). Testing API: [testing.md](testing.md). HTTP catalog: [api_reference.md](api_reference.md).
+
+## What hosts should extend
+
+| Stable Extension Point | Purpose |
+|------------------------|---------|
+| Routes | Additional host endpoints |
+| Controllers | Product-specific HTTP |
+| Workflows | Product orchestration |
+| Services | Product business logic |
+| `Communications::Produce` / `ProduceMany` | Sending messaging |
+| `FactoryBot.modify` | Extend shared factories |
+| Model reopen | Product associations / behavior |
+| Initializers | Configuration |
+| Notification catalogs / channel policy | Host-owned messaging customization |
+
+## Internal platform — do not extend
+
+| Internal Platform | Do Not Extend |
+|-------------------|---------------|
+| ApplicationWorkflow | Framework / shared orchestration base |
+| ServiceBase | Shared service framework |
+| Serializers | Platform response shaping |
+| Deserializers | Platform request trust boundary |
+| Messaging execution pipeline | Handoff / execution / accept internals |
+| RequestContext | Framework request context |
+| JWT primitives | Token issue / validate plumbing |
+| Internal framework plumbing | Envelope renderer, workflow base mechanics, etc. |
+
+Hosts **use** these via documented public APIs and configuration. Do not subclass, reopen, or fork them as product customization.
+
+## Generators and install flags
+
+Full install narrative: [initializing.md](initializing.md).
+
+| Surface | Notes |
+|---------|--------|
+| `bin/rails command_tower:install` | Migrations + optional configure |
+| `SKIP_CONFIGURE=1` | Migrations only |
+| `SKIP_MOUNT=1` | Initializer without mount |
+| `FORCE=1` | Overwrite initializer |
+| `rails g command_tower:configure` | `--skip-routes`, `--force` |
+
+## Mounting and configuration
+
+Mount `CommandTower::Engine` at the path your product needs. Configuration and secrets belong in the host initializer. Details: [initializing.md](initializing.md).
+
+## Migrations
+
+CommandTower authors CT-owned schema; hosts install via engine tasks (`command_tower:install:migrations` / `command_tower:install`) and run `db:migrate`. Do not dual-author CT schema in the host (**AD-SCH-01**). Details: [initializing.md](initializing.md).
+
+## Testing API and factories
+
+Primary SST: [testing.md](testing.md).
+
+| API | Role |
+|-----|------|
+| `CommandTower::Testing.install!` | Preferred host entry (loads factories) |
+| `CommandTower::Testing.load_factories!` | Factories only / advanced |
+| `CommandTower::Testing.ensure_endpoint_secret!` | Test helper for endpoint ciphertext when env unset |
+| `FactoryBot.modify` | Host extension of shared factories |
+
+Shipped factory files (under the gem `spec/factories/`): `user`, `user_secret`, messaging factories, `entity`, `role`.
+
+## RBAC on host controllers
+
+Protect host controllers with `authenticate_user!` / `authorize_user!` (or modern Auth boundaries) and RBAC entities. See [authentication_authorization_guide.md](authentication_authorization_guide.md) and [api_reference.md](api_reference.md).
+
+## Model reopen
+
+Prefer services/workflows for new behavior. Reopen patterns: [models.md](models.md).
+
+## Produce from product workflows
+
+Product business events own **host** workflows that call:
+
+- `CommandTower::Services::Messaging::Communications::Produce`
+- `CommandTower::Services::Messaging::Communications::ProduceMany`
+
+Do not create one Messaging workflow per message type. Do not call the messaging handoff/execution pipeline directly. Summary: [messaging_integration_guide.md](messaging_integration_guide.md).
+
+## Blank-host checklist
+
+1. Add gem → [initializing.md](initializing.md) quick start (`install`, `db:migrate`, `doctor`)
+2. Configure secrets and feature flags in the host initializer
+3. Mount the engine
+4. Load factories in the host test boot path → [testing.md](testing.md)
+5. Exercise shared surfaces via engine routes → [controllers.md](controllers.md) / [api_reference.md](api_reference.md)
+6. Add product routes/controllers/workflows/services only in the **stable extension** columns above
+7. Keep catalogs, channel policy, and adapter credentials host-owned
+
+No DoubleFloor Me (or other product) source is required to use the platform.
+
+## Related
+
+- [Architecture](architecture.md)
+- [Controllers](controllers.md)
+- [Sensitive changes](sensitive_routes.md)
+- Workflow guides: [password reset](password_reset_workflow.md), [change password](change_password_workflow.md), [email verification](email_verification_workflow.md)

--- a/docs/host_integration_guide.md
+++ b/docs/host_integration_guide.md
@@ -1,0 +1,158 @@
+# Host Integration Guide
+
+**Start here** for integrating CommandTower into a new Rails host.
+
+This page owns the **order of operations**. It does not replace specialty docs: install details stay in [Initializing](initializing.md), HTTP contracts in [API reference](api_reference.md), boundaries in [Extending](extending.md).
+
+`command_tower:doctor` green means secrets/migrations look sane. It does **not** prove Me/Auth authorization works.
+
+## Prerequisites
+
+- A Rails host application (engine is mounted into the host)
+- `gem "command_tower"` in the host Gemfile (path, git, or released gem)
+- Host-owned database (and any host Redis/job stack your app already uses)
+
+## Step 1 — Install
+
+Follow [Initializing](initializing.md):
+
+```bash
+bundle install
+bin/rails command_tower:install
+bin/rails db:migrate
+bin/rails command_tower:doctor
+```
+
+That copies CT migrations, generates `config/initializers/command_tower.rb` (unless skipped), and mounts `CommandTower::Engine` (unless skipped).
+
+## Step 2 — Secrets and initializer
+
+In the host initializer, set at least:
+
+- `config.jwt.hmac_secret`
+- `config.signup_session.jwt_secret` (or `SIGNUP_SESSION_JWT_SECRET`)
+- `config.password_recovery_session.jwt_secret` (or `PASSWORD_RECOVERY_SESSION_JWT_SECRET`)
+
+Re-run `bin/rails command_tower:doctor`. Details: [Initializing — Configuration](initializing.md#configuration).
+
+Dummy-host reference: [`rails_app/config/initializers/command_tower.rb`](../rails_app/config/initializers/command_tower.rb).
+
+## Step 3 — Confirm mount path
+
+Ensure routes include something like:
+
+```ruby
+mount CommandTower::Engine => "/"   # or "/api"
+```
+
+Engine paths below are **relative to that mount**. Route area index: [Controllers](controllers.md).
+
+## Step 4 — Host RBAC (required)
+
+AuthorizeRequest **fails closed**. Without host entity mappings, authenticated calls to `/me`, `/auth/session`, inbox, etc. return **403**.
+
+The configure generator does **not** create this file.
+
+1. Copy and adapt the dummy host file: [`rails_app/config/rbac_groups.yml`](../rails_app/config/rbac_groups.yml) → host `config/rbac_groups.yml`.
+2. Keep a host group such as `member` with entities for session, me, profile, inbox, preferences, phone, pushover, email verification.
+3. Do **not** redefine engine groups that already exist in `default.yml` (`owner`, `admin`).
+4. Point config at the file if needed:
+
+```ruby
+CommandTower.configure do |c|
+  c.authorization.rbac_group_path = Rails.root.join("config/rbac_groups.yml")
+end
+```
+
+(Default path is already `config/rbac_groups.yml`.)
+
+More: [Authorization](authorization.md), [Authentication & authorization guide](authentication_authorization_guide.md).
+
+## Step 5 — Roles on users
+
+RBAC YAML defines what a role **may** do. Users still need that role assigned.
+
+- Specs and the dummy pattern use role name **`member`** for Me/Auth surfaces.
+- Engine register does **not** automatically attach `member`. Hosts must assign roles via product logic, ops (`command_tower:users:create`), or host hooks after account creation.
+- Admin announcements need a role that includes `admin_messaging_announcements` (engine `admin` group, or an equivalent host mapping).
+
+## Step 6 — Enable feature gates you need
+
+When a gate is off, the route is **not drawn** → **404**.
+
+| Capability | Config |
+|------------|--------|
+| Plain-text login | `config.login.plain_text.enable = true` |
+| Email verification routes | `config.login.plain_text.email_verify = true` |
+| Password reset routes | `config.login.plain_text.password_reset = true` |
+| Email availability | `config.signup_session.email_availability = true` |
+| Username availability | `config.username.realtime_username_check = true` |
+
+Full gate list: [API reference — Feature gates](api_reference.md#feature-gates).
+
+## Step 7 — Choose auth client path
+
+- **API / mobile:** `Authorization: Bearer <jwt>` (default)
+- **Browser / SPA cookies:** enable `config.jwt.cookie` (+ CSRF as needed) — [Cookie authentication](cookie_authentication_guide.md)
+
+Engine HTTP success/error bodies use the application envelope `{ data, meta, errors }`. Host provisional helpers (`authenticate_user!`) can differ — [Authentication](authentication.md).
+
+## Step 8 — Smoke check
+
+With gates and RBAC in place (paths relative to your mount):
+
+1. `POST /auth/register` (always drawn) — create a user, then **assign `member`** (Step 5) if not done by host logic.
+2. `POST /auth/plain-text/login` (if enabled) — receive `data.token`.
+3. `GET /me` with Bearer token — expect **200** and envelope `data` (account payload).
+
+If you get **401**, authn failed. If you get **403**, fix Steps 4–5 before debugging clients.
+
+Contracts: [API reference](api_reference.md).
+
+## Step 9 — Messaging (when needed)
+
+Host owns:
+
+- Notification catalog / types
+- `platform_enabled_channels` / channel policy
+- Adapter credentials (email / SMS / Pushover)
+
+Emit from a **host product workflow** via `Communications::Produce` / `ProduceMany` — not by bypassing workflows. See [Messaging](messaging_integration_guide.md) and [Extending](extending.md).
+
+Phone/Pushover routes are always drawn; missing product readiness returns **503** capability errors.
+
+## Step 10 — Host tests
+
+```ruby
+require "command_tower/testing"
+CommandTower::Testing.install!
+```
+
+Details: [Testing](testing.md). Prefer `spec/requests/` patterns in the gem as HTTP contract proof.
+
+## Done when
+
+- Doctor passes for secrets/migrations
+- Host `rbac_groups.yml` maps Me/Auth entities
+- Users who should use Me surfaces have the host `member` (or equivalent) role
+- Needed feature gates are enabled
+- `GET /me` returns **200** with a Bearer token for a member user
+
+## Common failures
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Doctor green, `GET /me` is **403** | Missing host RBAC YAML or user lacks `member` (Steps 4–5) |
+| `POST /auth/plain-text/login` is **404** | `login.plain_text.enable?` off (Step 6) |
+| Password-reset / availability **404** | Matching feature gate off |
+| Phone / Pushover **503** | Capability / adapters not ready (Step 9) |
+| Confused error JSON on host controllers | Provisional `authenticate_user!` vs engine envelope (Step 7) |
+
+## Related
+
+- [Initializing](initializing.md)
+- [Extending](extending.md)
+- [API reference](api_reference.md)
+- [Authentication & authorization guide](authentication_authorization_guide.md)
+- [Messaging](messaging_integration_guide.md)
+- [README](../README.md)

--- a/docs/initializing.md
+++ b/docs/initializing.md
@@ -1,24 +1,169 @@
 # Initializing CommandTower
 
-Blah Blah Lazy....
+CommandTower is a Rails engine. The install flow below gets the engine **mounted, migrated, and doctor-checked**. That alone is not a fully usable Me/Auth host — complete RBAC, feature gates, and a smoke check via the [Host integration guide](host_integration_guide.md).
 
-Check out the Rails Generator.
+Back to [README](../README.md).
+
+## Quick start
+
+```bash
+# Gemfile: gem "command_tower"  (or path/git source)
+bundle install
+
+bin/rails command_tower:install
+bin/rails db:migrate
+bin/rails command_tower:doctor
 ```
-rails g command_tower:configure
+
+`command_tower:install` does **not** run `db:migrate`. Installing and migrating stay separate on purpose.
+
+### After install
+
+Continue with [Host integration](host_integration_guide.md):
+
+1. Host `rbac_groups.yml` (required — otherwise authenticated Me/Auth calls **403**)
+2. Assign host roles (for example `member`) on users
+3. Enable feature gates you need (login, reset, availability, …)
+4. Smoke-check `GET /me` with a Bearer token
+5. Wire messaging catalog/adapters when you emit or use phone/Pushover
+
+### What `command_tower:install` does
+
+1. Runs Rails-native `command_tower:install:migrations` (copies engine migrations into the host `db/migrate/` with `*.command_tower.rb` scope).
+2. Runs `rails g command_tower:configure` unless skipped (creates initializer; mounts the engine).
+3. Prints next steps.
+
+### Flags / environment
+
+| Variable | Effect |
+|----------|--------|
+| `SKIP_CONFIGURE=1` | Migrations only (existing custom initializer / mount) |
+| `SKIP_MOUNT=1` | Generate initializer but do not mount routes |
+| `FORCE=1` | Overwrite an existing `config/initializers/command_tower.rb` |
+
+Examples:
+
+```bash
+SKIP_CONFIGURE=1 bin/rails command_tower:install
+SKIP_MOUNT=1 bin/rails command_tower:install
+FORCE=1 bin/rails command_tower:install
 ```
 
-The Generator will:
+## Configure generator (optional)
 
-## Add Configuration file
-The configuration file will get generated in `config/initializers/command_tower.rb`. This file will contain a list of every config option that you can change. Additionally, it will provide details about what each configuration option does so you are not fumbling around.
+Prefer `command_tower:install` for greenfield hosts. The generator remains available:
 
-Check out the [Rails App Config file for an example](/rails_app/config/initializers/command_tower.rb)
+```bash
+bin/rails generate command_tower:configure
+bin/rails generate command_tower:configure --skip-routes
+bin/rails generate command_tower:configure --force
+```
 
-## Mounts the engine as a route
+The generator:
 
-To properly utilize this engine, it needs to get mounted in your applications route file. This will do it for you. Feel free to change the default path if desired
+1. Adds `config/initializers/command_tower.rb` when missing (or overwrites with `--force`).
+2. Mounts `CommandTower::Engine` unless `--skip-routes` or already mounted.
 
+Dummy-host example initializer (engine development): [`rails_app/config/initializers/command_tower.rb`](../rails_app/config/initializers/command_tower.rb).
 
-## Create DB migrations
-@matt-taylor to complete
+## Database migrations
 
+CommandTower is the **sole authoring authority** for CommandTower-owned schema (`db/migrate` inside the gem). Hosts must **not** manually write, edit, or copy-paste CommandTower schema migrations (**AD-SCH-01**).
+
+### Fresh host install
+
+Handled by `command_tower:install` (step 1). Equivalent migration-only command:
+
+```bash
+bin/rails command_tower:install:migrations
+bin/rails db:migrate
+```
+
+`command_tower:install:migrations` is the standard Rails engine task (wrapper around `railties:install:migrations`). Re-running installation is **idempotent**: already-installed CommandTower migrations are skipped.
+
+Rails may **retimestamp** newly copied host files. That is normal. Do not hand-edit installed `*.command_tower.rb` files.
+
+### Upgrade workflow
+
+1. Bump/release the CommandTower gem dependency in the host.
+2. Run `bin/rails command_tower:install:migrations` (or `SKIP_CONFIGURE=1 bin/rails command_tower:install`).
+3. Run `bin/rails db:migrate`.
+4. Optionally run `bin/rails command_tower:doctor`.
+
+Do not re-run configure on hosts that already customize the initializer unless you intend to regenerate it (`FORCE=1`).
+
+### Adding future migrations
+
+1. Author the migration **only** in CommandTower `db/migrate/`.
+2. Release / bump the gem in the host.
+3. Install + migrate as above.
+
+Installed host copies are an **execution context**, not a second authoring home.
+
+## Configuration
+
+Required for production-ready hosts:
+
+- `config.jwt.hmac_secret` — typically `SECRET_KEY_BASE` / `Rails.application.secret_key_base`
+- `config.signup_session.jwt_secret` — or `SIGNUP_SESSION_JWT_SECRET`
+- `config.password_recovery_session.jwt_secret` — or `PASSWORD_RECOVERY_SESSION_JWT_SECRET`
+
+Optional / feature-gated:
+
+- Messaging SMS / Pushover adapters and credential resolution (`config.credentials.*` or ENV)
+- Cookie + CSRF JWT modes
+- Admin enablement, application URL, welcome content hooks
+
+The generated initializer documents available options via class_composer. Defaults live in CommandTower; do not duplicate them unnecessarily in the host.
+
+## Doctor
+
+```bash
+bin/rails command_tower:doctor
+```
+
+Checks Rails version compatibility, engine baseline migrations, host-installed migration copies, JWT / session secrets, and messaging adapter names. Failures abort with remediation text; warnings print but allow success.
+
+Doctor does **not** probe Redis/SMTP connectivity.
+
+## Host vs CommandTower responsibilities
+
+| Concern | Owner |
+|---------|--------|
+| Author CT schema migrations | CommandTower |
+| Install / run migrations | Host (via engine tasks + `db:migrate`) |
+| Product configuration / secrets | Host initializer + ENV |
+| Dual-author CT schema in the host | **Forbidden** |
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `users already exists` on migrate | Database not empty / stale `schema.rb` load — migrate an empty DB, or dump schema after a clean migrate |
+| Install copies nothing new | Already installed — expected idempotency |
+| Missing tables after install | You installed but did not `db:migrate` |
+| Doctor fails on JWT default | Set `config.jwt.hmac_secret` from a real secret |
+| Accidental public engine mount | Use `SKIP_MOUNT=1` / `--skip-routes`, or mount at the path your product needs |
+
+## Existing customized hosts
+
+If the host already has a bespoke initializer and mount:
+
+```bash
+SKIP_CONFIGURE=1 bin/rails command_tower:install
+# same as: bin/rails command_tower:install:migrations
+bin/rails db:migrate
+```
+
+Do not run `rails g command_tower:configure` unless you intentionally want stock scaffolding.
+
+## Test suite factories
+
+Shared FactoryBot definitions ship with the gem. In the host test boot path:
+
+```ruby
+require "command_tower/testing"
+CommandTower::Testing.install!
+```
+
+Then extend with `FactoryBot.modify` as needed. See [Testing with CommandTower](testing.md).

--- a/docs/messaging_integration_guide.md
+++ b/docs/messaging_integration_guide.md
@@ -1,0 +1,87 @@
+# Messaging with CommandTower
+
+CommandTower owns modern messaging **platform** surfaces. Hosts supply product content, channel policy, and adapter credentials.
+
+Complete install and host RBAC first: [Host integration](host_integration_guide.md) (Steps 1–8 before emitting or wiring phone/Pushover).
+
+## Current surfaces
+
+| Concern | Path / entry |
+|---------|----------------|
+| User inbox (consume) | Engine `/me/inbox*` — see [API reference](api_reference.md#me-inbox) |
+| Preferences | Engine `/me/preferences*` — see [API reference](api_reference.md#preferences) |
+| Phone / Pushover endpoints | Engine `/me/phone*`, `/me/pushover*` (503 when capability unavailable) |
+| Single-recipient emit | `CommandTower::Services::Messaging::Communications::Produce` |
+| Multi-recipient emit | `CommandTower::Services::Messaging::Communications::ProduceMany` |
+| Admin cohort announce | Engine `POST /admin/messaging/announcements` |
+| Host ops announce | Host-owned rake/job (product-specific; not part of the gem) |
+
+Authentication uses JWT bearer or cookie session as documented in [Authentication](authentication.md). Me Inbox authorization requires host RBAC entities (dummy host uses a `member` role mapping). Admin announcements use entity `admin_messaging_announcements` (engine `default.yml` admin group).
+
+## Produce (single recipient)
+
+Call from a **product workflow**, not from a controller service bypass:
+
+```ruby
+CommandTower::Services::Messaging::Communications::Produce.call(
+  user: user,
+  notification_type_key: "welcome",
+  host_event_identity: "welcome/#{user.id}/#{SecureRandom.uuid}",
+  title: "Welcome",
+  body: "Thanks for joining.",
+  platform_enabled_channels: [:inbox, :email],
+  metadata: { source: "onboarding" } # optional
+)
+```
+
+| Kwarg | Required |
+|-------|----------|
+| `user` | yes (`User`) |
+| `notification_type_key` | yes (`String`) |
+| `host_event_identity` | yes (`String`) |
+| `title` | yes |
+| `body` | yes |
+| `platform_enabled_channels` | yes (`Array`) |
+| `metadata` | no (`Hash`) |
+
+## ProduceMany (multi recipient)
+
+| Kwarg | Required / notes |
+|-------|------------------|
+| `user_ids` | yes (`Array` of integer ids) |
+| `notification_type_key` | yes |
+| `campaign_identity` | yes — fan-out builds `host_event_identity` as `"#{campaign_identity}/#{user.id}"` |
+| `title`, `body` | yes |
+| `platform_enabled_channels` | yes |
+| `metadata` | optional |
+| `execution_mode` | optional, default `:async`; `:sync` capped at **25** recipients |
+
+Admin announcements HTTP is a product path over ProduceMany (async/sync, audience selection). Contract: [API reference — Admin messaging](api_reference.md#admin-messaging).
+
+## Me Inbox HTTP (summary)
+
+| Concern | Contract |
+|---------|----------|
+| List | `GET /me/inbox?limit=&offset=&scope=` — meta `{ limit, offset, totalCount }` |
+| Detail / open / archive / delete | `/me/inbox/:id` (+ `open`, `archive`) |
+| Bulk | `POST /me/inbox/bulk/{read,unread,archive,restore,delete}` with body `ids` |
+| Unread | `GET /me/inbox/unread-count` |
+
+Pagination detail: [pagination.md](pagination.md). Full catalog: [api_reference.md](api_reference.md#me-inbox).
+
+## Host responsibilities
+
+- Notification catalog content (registered into CommandTower notification types)
+- `platform_enabled_channels` / channel policy injection
+- Messaging adapter credentials (email / SMS / Pushover) via initializer or ENV
+- Host `rbac_groups.yml` entities for Me inbox/preferences/phone/pushover (and admin if used)
+- Product-specific operational tooling (announce rake tasks, welcome copy)
+
+## Related
+
+- [Controllers / routes](controllers.md)
+- [API reference](api_reference.md)
+- [Extending](extending.md) — Produce from host workflows; Do-Not-Extend
+- [Initializing](initializing.md) — configuration and doctor
+- [Pagination](pagination.md)
+- [README](../README.md)

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,14 +1,23 @@
 # CommandTower Models
 
+Core models live in the root / CommandTower namespaces and support authentication, authorization, and messaging ledger associations.
+
+Back to [README](../README.md).
+
 ## User
-The User model is the core model behind any user facing application.
 
-Through the User model, this engine is able to provide base competencies such as [Authentication via JWT](authentication.md) and [Authorization via RBAC](authorization.md).
+`User` is the primary identity model for host applications.
 
+It underpins [Authentication](authentication.md) and [Authorization](authorization.md), and participates in messaging via associations such as `messaging_communications`.
 
-Sometimes, you may want to add additional methods to the User Class. While we advocate for adding additional logic into Service objects, this may be unavoidable. To ReOpen the User Class simple do the following
+Sensitive session invalidation uses the user’s verifier token — see [Sensitive changes](sensitive_routes.md).
+
+### Reopening `User` in the host
+
+Prefer services/workflows for new behavior. When you must reopen the class:
+
 ```ruby
-require CommandTower::Engine.root.join("app","models", "user.rb")
+require CommandTower::Engine.root.join("app", "models", "user.rb")
 
 class User
   def self.my_class_method; end
@@ -17,14 +26,26 @@ end
 ```
 
 ## UserSecret
-This model helps back some of the validation components. For example, it backs the Email validation via PlaintText authentication. Additionally, it backs the core competency of [Sensitive Changes](sensitive_routes.md).
 
-Sometimes, you may want to add additional methods to the UserSecret Class. While we advocate for adding additional logic into Service objects, this may be unavoidable. To ReOpen the UserSecret Class simple do the following
+`UserSecret` backs validation and recovery-related secrets (for example plain-text email validation flows). It complements [Sensitive changes](sensitive_routes.md).
+
+### Reopening `UserSecret` in the host
+
 ```ruby
-require CommandTower::Engine.root.join("app","models", "user_secret.rb")
+require CommandTower::Engine.root.join("app", "models", "user_secret.rb")
 
 class UserSecret
   def self.my_class_method; end
   def my_instance_method; end
 end
 ```
+
+## Messaging models
+
+Engine-owned messaging persistence (communications, endpoints, preferences, and related records) ships with CommandTower. Prefer platform services/workflows for mutations; do not dual-author schema in the host ([Initializing](initializing.md)).
+
+## Related
+
+- [Architecture](architecture.md)
+- [Sensitive changes](sensitive_routes.md)
+- [Testing](testing.md) — shared factories for CT-owned models

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,118 +1,47 @@
 # Pagination
 
-Pagination allows a subset of information to be returned.
+CommandTower exposes one live HTTP list contract that returns pagination metadata: **Me Inbox**.
 
-## Configuration
+Back to [README](../README.md).
 
-Default configuration for everything is 10 unless otherwise configured or inputted. This value is changeable but it may come with a latency cost of how much data goes over the wire at once.
+## Me Inbox list contract
 
-### Default configuration
+`GET /me/inbox` accepts query parameters:
 
-Pagination Default configuration is available as part of the standard CommandTower Configuration.
+| Param | Default | Notes |
+|-------|---------|--------|
+| `limit` | `50` | Max `100` |
+| `offset` | `0` | |
+| `scope` | `"inbox"` | `"inbox"` or `"archived"` |
+
+Success envelope `meta`:
+
+```json
+{
+  "limit": 50,
+  "offset": 0,
+  "totalCount": 123
+}
+```
+
+`data` is an array of inbox items. Full route table: [API reference — Me Inbox](api_reference.md#me-inbox).
+
+Deserializer: `CommandTower::Deserializers::Messaging::Inbox::ListDeserializer`.
+
+## Global pagination config
+
+`CommandTower.config.pagination.limit` defaults to **10**. That value is a generic configuration default for pagination helpers — it is **not** the Me Inbox HTTP default (Inbox uses 50).
+
 ```ruby
 CommandTower.configure do |c|
-  # Default is 10 when running the initialization.
   c.pagination.limit = 50
 end
 ```
 
+There is no engine admin list endpoint and no `pagination=true` / `page` / `cursor` query API on current engine HTTP surfaces.
 
-## Usage
+## Related
 
-### As a Controller
-The [PaginationHelper](
-../app/helpers/command_tower/pagination_helper.rb) helps convert user input into what the [PaginationServiceHelper](
-../app/services/command_tower/pagination_service_helper.rb) expects.
-
-#### From the Query (Preferred)
-Go ahead and throw the values in the query! Pagination can help with handle that.
-
-To send as part of the query, the following parameters are used:
-
-`pagination=true`: This is a required Parameter. When not present, pagination via Query will not be used.
-
-- `limit=<Integer>`
-- `page=<Integer>`
-- `cursor=<Integer>` (Takes precedence over page)
-
-
-#### From the Body
-Prefer to send it as part of that body? Thats cool. Use this with caution as some Proxies may drop body parameters from GET requests.
-
-To send as part of the body, send in a hash with the key `pagination`
-```
-{
-  key1: 1,
-  key2: 2,
-  pagination: {
-    page:,
-    limit:,
-    cursor:,
-  }
-}
-```
-
-##### Examples
-- [CommandTower::Inbox::MessageController#metadata](../app/controllers/command_tower/inbox/message_controller.rb)
-- [CommandTower::AdminController#show](../app/controllers/command_tower/admin_controller.rb)
-
-### As a Service Base
-The [PaginationServiceHelper](
-../app/services/command_tower/pagination_service_helper.rb) is the the heavy lifter for all pagination in CommandTower.
-
-It is expected to get used from within a [CommandTower::ServiceBase](../app/services/command_tower/README.md) Object.
-
-#### Required Params
-Pagination values must be passed in as part of the context within a `pagination` hash.
-
-**pagination.limit**
-```
-Type: Integer
-Required: False -- Falls back to default pagination limit configured
-What: The max limit of records returned from the ServiceBase
-```
-
-**pagination.cursor**
-```
-Type: Integer
-Required: False -- Recommended page or cursor
-What: The starting offset in the database to return objects from. This value takes precedence over `page`
-```
-
-**pagination.page**
-```
-Type: Integer
-Required: False -- Recommended page or cursor
-What: Based on the limit, the starting page will calculate an offset to return objects from.
-```
-
-#### Service accessibility
-
-**Included in Service**: The [PaginationServiceHelper](
-../app/services/command_tower/pagination_service_helper.rb) must be included in your ServiceBase for pagination to function
-
-**Default Query Method**: In the ServiceBase, `default_query` must be set. This method should return a new query for your pagination needs. It should include any additional `where` or `select` clauses required for your object.
-
-**Pagination Schema Returned**: For added help, PaginationServiceHelper provides a `pagination_schema` method that returns a [Pagination](../lib/command_tower/schema/pagination.rb). This object can help your user better understand where they are in the page definition and what to call next
-
-```ruby
-class BasicExample < CommandTower::ServiceBase
-  include CommandTower::PaginationServiceHelper
-
-  def call
-    context.query = query
-    context.pagination
-  end
-
-  def default_query
-    Users.all
-  end
-end
-```
-
-#### Service Examples:
-
-- [CommandTower::AdminService::Users](../app/services/command_tower/admin_service/users.rb)
-
-- [CommandTower::InboxService::Message::Metadata](../app/services/command_tower/inbox_service/message/metadata.rb)
-
+- [API reference](api_reference.md)
+- [Messaging](messaging_integration_guide.md)
+- [Controllers](controllers.md)

--- a/docs/password_reset_workflow.md
+++ b/docs/password_reset_workflow.md
@@ -1,0 +1,82 @@
+# Password Reset (Forgot Password) Workflow
+
+Public password recovery for users who cannot authenticate. Flow uses a **password-recovery session** plus gated **password-reset** endpoints. Detailed schemas live here and are summarized in the [API reference](api_reference.md).
+
+## Purpose and orchestration
+
+| Step | Route | Workflow |
+|------|-------|----------|
+| Create recovery session | `POST /auth/password-recovery-session` | `Workflows::Auth::PasswordRecoverySession::CreateWorkflow` |
+| Send reset email | `POST /auth/password-reset/send` | `Workflows::Auth::PasswordReset::SendWorkflow` |
+| Validate token | `POST /auth/password-reset/validate` | `Workflows::Auth::PasswordReset::ValidateWorkflow` |
+| Reset password | `POST /auth/password-reset/reset` | `Workflows::Auth::PasswordReset::ResetWorkflow` |
+
+All listed workflows inherit `ApplicationWorkflow` with `retry_strategy :none`. Controllers under `CommandTower::Auth::PasswordReset::*` and password-recovery-session authenticate the recovery session where required, deserialize, run **one** workflow, and render `WorkflowResult`.
+
+**Feature gate:** `CommandTower.config.login.plain_text.password_reset?` (reset endpoints). Recovery session creation is part of the public recovery path.
+
+**Boundary:** Controllers own transport + recovery-session auth. Workflows orchestrate rate limits and password-reset services. Services own email/token capability details. Do not call messaging execution internals from hosts — see [extending.md](extending.md).
+
+## High-level characteristics
+
+- **No user JWT**; `password-reset/send` requires a valid **password-recovery session**; `validate` / `reset` are public and use the emailed reset `token` in the body
+- Email-based identification; responses avoid user enumeration where designed to
+- Secure, time-limited reset tokens
+- Rate limiting via password-recovery rate-limit services
+
+## Endpoints (engine-relative)
+
+### 1. Create password-recovery session
+
+`POST /auth/password-recovery-session`
+
+Establishes the recovery session used by subsequent reset calls. See request specs under `spec/requests/` for exact payload/envelope.
+
+### 2. Send reset email
+
+`POST /auth/password-reset/send`
+
+**Auth:** Password-recovery session  
+
+**Body (typical):** `{ "email": "string" }`  
+
+**Workflow:** `SendWorkflow` → rate-limit check → `Services::Auth::PasswordReset::Send`
+
+### 3. Validate token
+
+`POST /auth/password-reset/validate`
+
+**Auth:** Public (reset token in body)
+
+**Body (typical):** `{ "token": "string" }` (optional `email` when config requires it)
+
+**Workflow:** `ValidateWorkflow`
+
+### 4. Reset password
+
+`POST /auth/password-reset/reset`
+
+**Auth:** Public (reset token in body)
+
+**Body (typical):** token + new password fields (`passwordConfirmation` / `password_confirmation`)
+
+**Workflow:** `ResetWorkflow`
+
+Success behavior and verifier rotation differ from authenticated [change password](change_password_workflow.md) — treat recovery success per product policy (often force Sign In).
+
+## Errors
+
+Failures return the standard application envelope via `render_application_result`. Status mapping uses Auth identity/password-reset error helpers. Validation failures from deserializers typically surface as `422 Unprocessable Entity`.
+
+## Security notes
+
+- Never log passwords, raw tokens, or recovery-session secrets
+- Prefer HTTPS in production
+- Respect rate limits; do not probe for account existence in client UX
+
+## Related
+
+- [Change password workflow](change_password_workflow.md)
+- [API reference](api_reference.md)
+- [Initializing](initializing.md) — secrets / feature config
+- [Extending](extending.md)

--- a/docs/sensitive_routes.md
+++ b/docs/sensitive_routes.md
@@ -1,0 +1,47 @@
+# Sensitive changes and session invalidation
+
+CommandTower JWTs are bound to the authenticated user’s **verifier token**. When the verifier rotates, previously issued access tokens that carried the old verifier no longer authenticate (`401`).
+
+This is the platform mechanism behind “logout everywhere” and post-password-change session invalidation.
+
+## Verifier token on `User`
+
+Each `User` may store:
+
+- `verifier_token` — opaque string embedded in JWTs at issue time
+- `verifier_token_last_reset` — timestamp of the last rotation
+
+API:
+
+```ruby
+user.reset_verifier_token!    # generates a new token, updates timestamp, returns the value
+user.retreive_verifier_token! # returns existing token or creates one (historical spelling)
+```
+
+Authentication compares the verifier claim in the JWT to the user’s current `verifier_token`. A mismatch fails authentication.
+
+## When the platform rotates the verifier
+
+| Event | Behavior |
+|-------|----------|
+| Authenticated password change (`PATCH /me/password`) | Rotates verifier so prior tokens fail |
+| Host / ops call `user.reset_verifier_token!` | Explicit revoke-all-sessions |
+
+There is no engine HTTP admin “mutate user with `verifier_token: true`” route. `UserAttributes::Mutate` may still exist for internal/host use; do not assume a public SchemaHelper admin path.
+
+Browser `POST /auth/logout` clears cookie/session transport for that client; it does **not** by itself rotate `verifier_token` for all devices. Use verifier rotation when all outstanding JWTs must die.
+
+## Host guidance
+
+- Treat password changes and explicit “revoke all sessions” as **sensitive** operations that should rotate the verifier.
+- Do not expose `verifier_token` in API payloads (platform serializers omit it).
+- Prefer platform workflows/services for password change rather than hand-editing password digests without rotation.
+- `UserSecret` backs related validation/recovery secrets; see [Models](models.md).
+
+## Related
+
+- [Change password workflow](change_password_workflow.md)
+- [Authentication](authentication.md) / [Authentication & authorization guide](authentication_authorization_guide.md)
+- [Cookie authentication](cookie_authentication_guide.md)
+- [Models](models.md)
+- [README](../README.md)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,74 @@
+# Testing with CommandTower
+
+CommandTower ships FactoryBot definitions for engine-owned models. Hosts load
+them explicitly in the test suite — there is no production Railtie and
+FactoryBot is not a runtime gem dependency.
+
+Back to [README](../README.md). See also [Initializing](initializing.md).
+
+## Setup
+
+```ruby
+# spec/rails_helper.rb (after Rails is loaded)
+require "command_tower/testing"
+
+CommandTower::Testing.install! # preferred
+# CommandTower::Testing.load_factories! # factories-only / advanced
+```
+
+Call `install!` **before** any host `FactoryBot.modify` blocks so shared
+factories exist when you extend them.
+
+## Extending factories
+
+Hosts must not redefine CommandTower base factories. Use `FactoryBot.modify`:
+
+```ruby
+FactoryBot.modify do
+  factory :user do
+    roles { ["member"] }
+
+    trait :operator do
+      roles { %w[member operator] }
+    end
+  end
+end
+```
+
+## Packaging and evolution
+
+Factory files live under `spec/factories/**` inside the gem and are included in
+the gemspec. Adding or changing a shared factory is a normal CommandTower gem
+bump — hosts pick it up on upgrade.
+
+`CommandTower::Testing.load_factories!` is idempotent (safe to call more than
+once). It loads each factory file under `CommandTower::Engine.root/spec/factories`
+explicitly; it does not append to global `FactoryBot.definition_file_paths`.
+
+## Responsibilities
+
+| Owner | Responsibility |
+|-------|----------------|
+| CommandTower | Base factories for CT-owned models; Testing API; packaging |
+| Host | `install!` in the test boot path; product traits via `FactoryBot.modify` |
+
+## Factory invariant
+
+Base factories construct **persistent model state only**. They must not invoke
+Services, Workflows, ApplicationWorkflows, or external adapters. Endpoint
+ciphertext uses `SecretBox` / `Fingerprinter` (crypto helpers).
+
+For endpoint factories in environments where
+`COMMAND_TOWER_MESSAGING_ENDPOINT_SECRET` is unset, you may call:
+
+```ruby
+CommandTower::Testing.ensure_endpoint_secret!
+```
+
+(SecretBox already falls back to a non-production test secret outside production.)
+
+## Contributors vs hosts
+
+This guide is the **host Testing API**. Contributors working inside the CommandTower
+repository also follow workspace test standards (`.cursor/rules/testing.mdc`) and
+architecture guards under `spec/architecture/`.

--- a/docs/upgrades/0.10.0.md
+++ b/docs/upgrades/0.10.0.md
@@ -1,0 +1,58 @@
+# Upgrade: CommandTower 0.10.0
+
+**From:** `0.5.0` (and earlier SchemaHelper-era hosts on `main`)  
+**To:** `0.10.0`
+
+This document summarizes **all changes from `main` through the `0.10.0` release** (committed work on `schematizing` plus the modern platform working tree). It is the durable upgrade / change SST for hosts. For a sequenced blank-host path, use [Host integration](../host_integration_guide.md).
+
+## Breaking / host-impact
+
+| Change | Host impact |
+|--------|-------------|
+| SchemaHelper Admin / User / legacy Inbox HTTP removed | No `GET /user`, `/user/modify`, `/admin/modify*`, legacy blast/message SchemaHelper routes |
+| Modern response envelope | Engine HTTP returns `{ data, meta, errors }` via `render_application_result` |
+| Current-user path | Use `GET /me` (and `GET /profile`); not `GET /user` |
+| Login path | `POST /auth/plain-text/login` when `login.plain_text.enable?` (route absent → **404** if gate off) |
+| Password change | `PATCH /me/password` (rotates verifier; does not re-issue JWT) |
+| Host RBAC required | Without host `rbac_groups.yml` entity mappings, Me/Auth calls **403** (fail-closed) |
+| Feature gates | Login, email verify, password reset, availability routes are config-gated |
+| Schema ownership (**AD-SCH-01**) | CT authors migrations; hosts install via `command_tower:install` / `install:migrations` then `db:migrate` |
+| Admin HTTP | Only `POST /admin/messaging/announcements` (no SchemaHelper user admin) |
+
+## Platform capabilities in 0.10.0
+
+- **Auth:** register, plain-text login, logout, session, identity policy, signup session, email/username availability, email verification, password-recovery session + password reset
+- **Me:** account show, profile, name, password, inbox (list/detail/bulk), preferences, phone, Pushover
+- **Messaging emit:** `Communications::Produce` / `ProduceMany` from host workflows
+- **Install:** `command_tower:install`, configure generator, `command_tower:doctor`
+- **Testing:** `CommandTower::Testing.install!` shared factories
+- **Architecture:** Controller → Workflow → Service; Engine uses `authenticate_request!` / `authorize_request!`
+
+## Documentation
+
+- Canonical HTTP catalog: [API reference](../api_reference.md)
+- Host start-here: [Host integration](../host_integration_guide.md)
+- Install SST: [Initializing](../initializing.md)
+- Auth/cookie/RBAC guides refreshed to modern routes
+- Messaging and pagination aligned to Inbox + Produce contracts
+
+## Upgrade checklist (existing hosts)
+
+1. Bump gem to `0.10.0` and run `bin/rails command_tower:install:migrations` (or `SKIP_CONFIGURE=1 bin/rails command_tower:install`) then `bin/rails db:migrate`.
+2. Set JWT + signup/recovery session secrets; run `bin/rails command_tower:doctor`.
+3. Copy/adapt [`rails_app/config/rbac_groups.yml`](../../rails_app/config/rbac_groups.yml) into the host; do not redefine engine `owner` / `admin` groups.
+4. Ensure users who need Me surfaces have the host `member` role (or equivalent).
+5. Enable feature gates you rely on (`login.plain_text.enable`, password reset, email verify, availability).
+6. Point clients at modern paths (`/me`, `/auth/plain-text/login`, envelope parsing).
+7. Smoke: Bearer login → `GET /me` returns **200** (not **403**).
+8. If emitting messages: catalog, channels, adapters; call Produce from host workflows.
+
+New hosts: follow [Host integration](../host_integration_guide.md) end-to-end.
+
+## Related
+
+- [Initializing](../initializing.md)
+- [Extending](../extending.md)
+- [Messaging](../messaging_integration_guide.md)
+- [Authentication & authorization guide](../authentication_authorization_guide.md)
+- [README](../../README.md)

--- a/docs/upgrades/README.md
+++ b/docs/upgrades/README.md
@@ -1,0 +1,9 @@
+# Upgrades
+
+Host-facing upgrade / change summaries for CommandTower releases.
+
+| Version | Summary |
+|---------|---------|
+| [0.10.0](0.10.0.md) | Modern Auth/Me/Messaging platform; SchemaHelper removal; host RBAC required |
+
+New hosts should start with [Host integration](../host_integration_guide.md).

--- a/lib/command_tower/version.rb
+++ b/lib/command_tower/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CommandTower
-  VERSION = "0.4.0"
+  VERSION = "0.10.0"
 end


### PR DESCRIPTION
## Summary

- Lands the **docs + version** slice of the 0.10.0 merge train (single commit on top of messaging).
- Host integration guide, upgrade summary (`docs/upgrades/0.10.0.md`), refreshed API/auth/messaging docs.
- Sets `CommandTower::VERSION` to **0.10.0**.
- Base: `release/0.10.0-messaging`.

## Upgrade / full change summary

See [docs/upgrades/0.10.0.md](docs/upgrades/0.10.0.md) on this branch.

## Test plan

- [ ] Doc links resolve
- [ ] VERSION is `0.10.0`
- [ ] No platform code beyond docs/README/version in this commit


Made with [Cursor](https://cursor.com)